### PR TITLE
Fix: Correct executable name in Dockerfile entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,4 +14,4 @@ RUN cargo build --release
 EXPOSE 8080
 EXPOSE 9090
 
-CMD ["/app/target/release/rucho", "start"]
+CMD ["/app/target/release/echo-server", "start"]


### PR DESCRIPTION
The CMD instruction in the Dockerfile was pointing to 'rucho' as the executable name. This has been corrected to 'echo-server' to match the package name defined in Cargo.toml.