### PR TITLE
feat: Add swagger-ui and delay endpoints to /endpoints output

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,8 @@ rustls-pemfile = "1.0"
 hyper = { version = "1.0", features = ["server"] }
 http = "1.0"
 axum-server = { version = "0.7", features = ["tls-rustls"] }
+utoipa = { version = "4", features = ["axum_extras"] }
+utoipa-swagger-ui = { version = "7", features = ["axum"] }
 
 [dev-dependencies]
 tempfile = "3.8.0"

--- a/README.md
+++ b/README.md
@@ -22,15 +22,17 @@ src/
 ├── main.rs             # Application entrypoint
 ├── lib.rs              # Library module declarations
 ├── routes/             # HTTP route handlers
-│   ├── delete.rs
-│   ├── get.rs
-│   ├── options.rs
-│   ├── patch.rs
-│   ├── post.rs
-│   ├── put.rs
-│   └── status.rs
-└── utils/
-    └── json_response.rs  # Shared JSON response helper
+│   ├── core_routes.rs  # Core echo and utility endpoints
+│   ├── delay.rs        # Delay endpoint
+│   ├── healthz.rs      # Health check endpoint
+│   └── mod.rs          # Routes module declaration
+└── utils/              # Utility modules
+    ├── config.rs       # Configuration loading
+    ├── error_response.rs # Standardized error responses
+    ├── json_response.rs  # Standardized JSON responses
+    ├── mod.rs          # Utils module declaration
+    ├── request_models.rs # Request model structs (e.g., query params)
+    └── server_config.rs # Server listener and TLS configuration
 ```
 
 ---
@@ -65,23 +67,48 @@ http://localhost:8080
 
 | Method   | Path              | Description                                      |
 |:--------:|:------------------:|:------------------------------------------------:|
-| GET      | `/`                | Welcome message ("Hello, World!")                |
-| GET      | `/get`             | Echo request headers as JSON                    |
-| POST     | `/post`            | Echo request body as JSON                       |
-| PUT      | `/put`             | Echo request body as JSON                       |
-| PATCH    | `/patch`           | Echo request body as JSON                       |
-| DELETE   | `/delete`          | Echo request body as JSON                       |
-| OPTIONS  | `/options`         | Returns allowed HTTP methods                   |
-| GET      | `/status/:code`    | Responds with requested HTTP status code        |
+| GET      | `/`                | Welcome message                                  |
+| GET      | `/get`             | Echoes request details for GET                   |
+| HEAD     | `/get`             | Responds with headers for GET query              |
+| POST     | `/post`            | Echoes request details for POST, expects JSON body |
+| PUT      | `/put`             | Echoes request details for PUT, expects JSON body  |
+| PATCH    | `/patch`           | Echoes request details for PATCH, expects JSON body|
+| DELETE   | `/delete`          | Echoes request details for DELETE                |
+| OPTIONS  | `/options`         | Responds with allowed HTTP methods               |
+| ANY      | `/status/:code`    | Returns the specified HTTP status code           |
+| ANY      | `/anything`        | Echoes request details for any HTTP method       |
+| ANY      | `/anything/*path`  | Echoes request details for any HTTP method under a specific path |
+| GET      | `/delay/:n`        | Delays response by `n` seconds                   |
+| GET      | `/healthz`         | Performs a health check, returns "OK"            |
+| GET      | `/endpoints`       | Lists all available API endpoints                |
+| GET      | `/swagger-ui`      | Displays OpenAPI/Swagger UI documentation        |
+
+---
+
+## OpenAPI/Swagger Documentation
+
+Rucho includes OpenAPI (Swagger) documentation for its API endpoints.
+You can access the Swagger UI by navigating to `/swagger-ui` in your browser when the server is running.
+
+Example: `http://localhost:8080/swagger-ui`
+
+The OpenAPI specification is available at `/api-docs/openapi.json`.
 
 ---
 
 ## 🧹 Features
 
-- 📜 Clean JSON response formatting with newline.
+- 📜 Clean JSON response formatting with newline (optional pretty-printing via `?pretty=true`).
 - 📈 Automatic request tracing and logging using `TraceLayer`.
-- 🔥 Support for all major HTTP methods (GET, POST, PUT, PATCH, DELETE, OPTIONS).
+- 🔥 Support for all major HTTP methods (GET, POST, PUT, PATCH, DELETE, OPTIONS, HEAD, ANY).
 - ⚡ Dynamic HTTP status simulation (`/status/200`, `/status/503`, etc).
+- ⏱️ Configurable response delay endpoint (`/delay/:n`).
+- ❤️ Health check endpoint (`/healthz`).
+- 📖 Self-documenting API with OpenAPI/Swagger UI (`/swagger-ui`).
+- 🗄️ Endpoint listing (`/endpoints`).
+- ⚙️ Flexible configuration via files and environment variables.
+- 🔒 Optional HTTPS support via Rustls.
+- 🐳 Docker support with a non-root user.
 - 🧹 Organized modular structure for easy expansion and maintenance.
 
 ---

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -7,18 +7,18 @@
 - ✅ `/healthz` endpoint
 - ✅ Optional pretty JSON output (`?pretty=true`)
 - ✅ Graceful shutdown handling (SIGINT/SIGTERM)
-- ✅ Support additional HTTP methods (HEAD, OPTIONS)
+- ✅ Support additional HTTP methods (HEAD, OPTIONS, ANY)
 
 ---
 
 ## 🥈 Tier 2: Developer Utility Endpoints (Completed ✅)
 
 - ✅ `/delay/:n` — delay response by `n` seconds
-- [ ] `/status/XXX` — return specified HTTP status code
+- ✅ `/status/:code` — return specified HTTP status code (supports ANY method)
 - [ ] WebSocket echo support
 - [ ] gRPC echo server
-- [ ] Add support for HTTP/2 or HTTP/3
-- [ ] Add HTTPS support
+- ✅ Add support for HTTP/2 (via Axum and Hyper, enabled with TLS)
+- ✅ Add HTTPS support (via Rustls)
 
 ---
 
@@ -27,9 +27,9 @@
 - [ ] JSON structured server logs
 - [ ] Panic recovery middleware
 - [ ] Request/response size metrics
-- [ ] Dockerfile for container builds
+- ✅ Dockerfile for container builds
 - [ ] Helm Chart for Kubernetes deployment
-- [ ] OpenAPI/Swagger documentation
+- ✅ OpenAPI/Swagger documentation
 
 ---
 
@@ -58,8 +58,11 @@
 # 📢 Status
 
 ✅ Basic Echo Server working  
-✅ /anything endpoint live  
+✅ `/anything` endpoint live (supports ANY method and subpaths)
+✅ `/endpoints` endpoint lists all available API endpoints
 ✅ Modular routes and utils organized  
+✅ Configuration loading via files and environment variables
+✅ CORS support (permissive)
 🚧 Tier 3 features under development  
 
 ---
@@ -82,8 +85,9 @@ MIT License
 | Phase | Focus |
 |:---|:---|
 | Phase 1 | ✅ Finish Tier 1 (Core improvements) |
-| Phase 2 | ✅ Complete `/delay/:n` endpoint |
-| Phase 3 | 🚧 Productionize (Tier 3: Logs, Middleware, Docker) |
-| Phase 4 | (Optional) Bonus Protocols like WebSockets, gRPC |
+| Phase 2 | ✅ Complete Tier 2 (Developer Utility Endpoints like `/delay/:n`, `/status/:code`, HTTPS, HTTP/2) |
+| Phase 3 | ✅ Complete OpenAPI/Swagger documentation and Dockerfile (Tier 3) |
+| Phase 4 | 🚧 Continue Tier 3 Productionization (Logs, Middleware, Helm) |
+| Phase 5 | (Optional) Bonus Protocols like WebSockets, gRPC & Future Bonus Ideas |
 
 ---

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,9 @@
-// Make the `routes` module public so it can be accessed from other parts of the project
+/// The `routes` module contains all the route handlers for the Rucho web server.
+///
+/// This module defines the API endpoints and their corresponding logic.
 pub mod routes;
 
-// Make the `utils` module public so it can be accessed from other parts of the project
+/// The `utils` module provides utility functions and structures used throughout the Rucho application.
+///
+/// This includes configuration management, server setup, and other helper functionalities.
 pub mod utils;

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,8 +9,8 @@ use std::process;
 use std::str::FromStr; // Added import
 use sysinfo::{Pid, Signal, System}; // SystemExt will be used via the System struct directly
 use axum::Router;
-use std::net::SocketAddr; // Already added in a previous step, but good to confirm
-use tokio::{net::TcpListener, signal};
+// use std::net::SocketAddr; // Removed as per build error (unused import)
+use tokio::signal; // net::TcpListener removed as per build error (unused import)
 use tower_http::{
     cors::CorsLayer,
     normalize_path::NormalizePathLayer,
@@ -20,27 +20,70 @@ use tracing::Level; // Added import
 use tracing_subscriber;
 use axum_server::Handle; // bind_rustls and Server are unused
 // crate::utils::server_config::try_load_rustls_config will be used directly with crate:: prefix
+use utoipa::OpenApi;
+use utoipa_swagger_ui::SwaggerUi;
+use crate::routes::core_routes::EndpointInfo; // Ensure EndpointInfo is imported
+use crate::utils::request_models::PrettyQuery; // Ensure PrettyQuery is imported
+// Import other necessary types that are part of API responses or requests if any
 
 // Temporarily comment out reqwest for build purposes
 // use reqwest;
 
+/// Represents the command line arguments passed to the application.
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
 pub struct Args {
+    /// The subcommand to execute.
     #[command(subcommand)]
     command: CliCommand,
 }
 
+/// Defines the available subcommands for the CLI.
 #[derive(Parser, Debug)]
 pub enum CliCommand {
+    /// Starts the Rucho server.
     Start {},
+    /// Stops the Rucho server.
     Stop {},
+    /// Checks the status of the Rucho server.
     Status {},
+    /// Displays the version of Rucho.
     Version {},
 }
 
+#[derive(OpenApi)]
+#[openapi(
+    paths(
+        routes::core_routes::root_handler,
+        routes::core_routes::get_handler,
+        routes::core_routes::head_handler,
+        routes::core_routes::post_handler,
+        routes::core_routes::put_handler,
+        routes::core_routes::patch_handler,
+        routes::core_routes::delete_handler,
+        routes::core_routes::options_handler,
+        routes::core_routes::status_handler,
+        routes::core_routes::anything_handler,
+        routes::core_routes::anything_path_handler,
+        routes::core_routes::endpoints_handler,
+        routes::delay::delay_handler,
+        routes::healthz::healthz_handler,
+    ),
+    components(
+        schemas(EndpointInfo, PrettyQuery, routes::core_routes::Payload)
+    ),
+    tags(
+        (name = "Rucho", description = "Rucho API")
+    )
+)]
+struct ApiDoc;
+
 const PID_FILE: &str = "/var/run/rucho/rucho.pid";
 
+/// The main entry point for the Rucho application.
+///
+/// Parses command line arguments, initializes configuration and logging,
+/// and executes the appropriate command.
 #[tokio::main]
 async fn main() {
     let args = Args::parse();
@@ -158,6 +201,10 @@ async fn main() {
     }
 }
 
+/// Runs the Axum web server with the provided configuration.
+///
+/// This function sets up the HTTP/S listeners, configures routing,
+/// and handles graceful shutdown.
 async fn run_server(config: &Config) { // Takes config as an argument
     // tracing_subscriber::fmt::init(); // This is now done in main
 
@@ -165,6 +212,7 @@ async fn run_server(config: &Config) { // Takes config as an argument
     let shutdown = shutdown_signal(handle.clone());
 
     let app = Router::new()
+        .merge(SwaggerUi::new("/swagger-ui").url("/api-docs/openapi.json", ApiDoc::openapi()))
         .merge(routes::core_routes::router())
         .merge(routes::healthz::router())
         .merge(routes::delay::router())
@@ -245,6 +293,7 @@ async fn run_server(config: &Config) { // Takes config as an argument
     }
 }
 
+/// Listens for a Ctrl+C signal to initiate a graceful shutdown of the server.
 async fn shutdown_signal(handle: Handle) {
     signal::ctrl_c()
         .await

--- a/src/routes/delay.rs
+++ b/src/routes/delay.rs
@@ -1,13 +1,30 @@
 // delay.rs
-use axum::{routing::any, Router, body::Body, extract::Path, http::Method, response::IntoResponse};
-use std::time::Duration;
-use tokio::time::sleep;
+use axum::{routing::any, Router};
+// Unused imports were: body::Body, extract::Path, http::Method, response::IntoResponse
+// Unused imports from std/tokio were: std::time::Duration, tokio::time::sleep
 
-pub fn router() -> Router {
-    Router::new().route("/delay/:n", any(delay_handler))
+/// Handles requests to the `/delay/:n` endpoint.
+///
+/// Introduces a delay of `n` seconds before sending a response.
+/// The delay duration `n` is extracted from the path.
+#[utoipa::path(
+    get, post, put, patch, delete, options, head,
+    path = "/delay/{n}",
+    params(
+        ("n" = u64, Path, description = "Number of seconds to delay the response")
+    ),
+    responses(
+        (status = 200, description = "Responds after the specified delay", body = String)
+    )
+)]
+async fn delay_handler(axum::extract::Path(n): axum::extract::Path<u64>, _method: axum::http::Method, _body: axum::body::Body) -> impl axum::response::IntoResponse {
+    tokio::time::sleep(std::time::Duration::from_secs(n)).await;
+    format!("Response delayed by {} seconds", n)
 }
 
-async fn delay_handler(Path(n): Path<u64>, _method: Method, _body: Body) -> impl IntoResponse {
-    sleep(Duration::from_secs(n)).await;
-    format!("Response delayed by {} seconds", n)
+/// Creates and returns the Axum router for the delay endpoint.
+///
+/// This router provides an endpoint that introduces an artificial delay before responding.
+pub fn router() -> Router {
+    Router::new().route("/delay/:n", any(delay_handler))
 }

--- a/src/routes/healthz.rs
+++ b/src/routes/healthz.rs
@@ -1,10 +1,23 @@
 // healthz.rs
 use axum::{routing::get, Router, response::IntoResponse, http::StatusCode};
 
+/// Creates and returns the Axum router for the health check endpoint.
+///
+/// This router provides a simple `/healthz` endpoint that returns an HTTP 200 OK status.
 pub fn router() -> Router {
     Router::new().route("/healthz", get(healthz_handler))
 }
 
+/// Handles requests to the `/healthz` endpoint.
+///
+/// Returns an HTTP 200 OK status and the plain text "OK".
+#[utoipa::path(
+    get,
+    path = "/healthz",
+    responses(
+        (status = 200, description = "Health check successful", body = String)
+    )
+)]
 async fn healthz_handler() -> impl IntoResponse {
     (StatusCode::OK, "OK")
 }

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -1,5 +1,8 @@
 // Make each route module public so they can be used elsewhere in the project
 
+/// Module for core API routes, including various HTTP method handlers and utility endpoints.
 pub mod core_routes; // Consolidated routes
+/// Module for the health check endpoint (`/healthz`).
 pub mod healthz;
+/// Module for the delay endpoint (`/delay/:n`).
 pub mod delay;

--- a/src/utils/error_response.rs
+++ b/src/utils/error_response.rs
@@ -6,7 +6,19 @@ use axum::{
 };
 use serde_json::json;
 
-/// Formats a JSON error response with the given status code and message
+/// Formats a JSON error response.
+///
+/// Creates a standardized JSON response object with an "error" field containing the provided message.
+/// The HTTP status code and "Content-Type: application/json" header are also set.
+///
+/// # Arguments
+///
+/// * `status`: The `StatusCode` for the HTTP response.
+/// * `message`: A string slice (`&str`) containing the error message.
+///
+/// # Returns
+///
+/// An Axum `Response` object.
 pub fn format_error_response(status: StatusCode, message: &str) -> Response {
     let error_body = json!({
         "error": message

--- a/src/utils/json_response.rs
+++ b/src/utils/json_response.rs
@@ -5,9 +5,20 @@ use axum::{
 };
 use serde_json::Value;                   // Represents arbitrary JSON values
 
-/// Takes a JSON Value and returns a properly formatted HTTP Response
-/// 
-/// `pretty`: controls whether the JSON is compact (default) or pretty-printed (indented).
+/// Formats a `serde_json::Value` into an Axum `Response`.
+///
+/// This function serializes the given JSON `Value` into a string.
+/// The response will have an HTTP 200 OK status and a "Content-Type: application/json" header.
+///
+/// # Arguments
+///
+/// * `data`: A `serde_json::Value` to be serialized and sent in the response body.
+/// * `pretty`: A boolean indicating whether the JSON output should be pretty-printed (true)
+///   or compact (false).
+///
+/// # Returns
+///
+/// An Axum `Response` object.
 pub fn format_json_response(data: Value, pretty: bool) -> Response {
     // Serialize the JSON Value to a String based on the `pretty` flag
     let body = if pretty {

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,7 +1,13 @@
 // Make the `json_response` module public
 // This allows other parts of the project (like main.rs and route handlers) to use `utils::json_response::format_json_response`
+
+/// Module for application configuration loading and management.
 pub mod config; // Added
+/// Module for creating standardized JSON error responses.
 pub mod error_response;
+/// Module for creating standardized JSON responses.
 pub mod json_response;
+/// Module defining common request model structures, like query parameters.
 pub mod request_models;
+/// Module for server-specific configurations, including listener parsing and SSL setup.
 pub mod server_config;

--- a/src/utils/request_models.rs
+++ b/src/utils/request_models.rs
@@ -1,6 +1,13 @@
 use serde::Deserialize;
+use utoipa::ToSchema;
 
-#[derive(Debug, Deserialize)]
+/// Represents common query parameters for requests, such as `pretty`.
+///
+/// This struct is used to deserialize query parameters that control aspects like
+/// the formatting of JSON responses.
+#[derive(Debug, Deserialize, ToSchema, utoipa::IntoParams)]
 pub struct PrettyQuery {
+    /// If `true`, indicates that the JSON response should be pretty-printed.
+    /// If `false` or absent, the JSON response will be compact.
     pub pretty: Option<bool>,
 }

--- a/src/utils/server_config.rs
+++ b/src/utils/server_config.rs
@@ -6,8 +6,24 @@
 use std::path::PathBuf;
 use axum_server::tls_rustls::RustlsConfig;
 
-/// Determines whether to launch with HTTPS or plain HTTP.
-/// Returns either a `RustlsConfig` if certs are found, or `None` for plain HTTP.
+/// Attempts to load Rustls configuration for enabling HTTPS.
+///
+/// This function checks for the existence of SSL certificate and key files at the
+/// paths provided. If both files are found and valid, it returns a `RustlsConfig`
+/// suitable for configuring an Axum server with TLS.
+///
+/// If either path is not provided, or if the files are not found or are invalid,
+/// this function logs a warning/error and returns `None`, indicating that TLS
+/// should not be enabled.
+///
+/// # Arguments
+///
+/// * `ssl_cert_path_opt`: An `Option<&str>` containing the path to the SSL certificate file.
+/// * `ssl_key_path_opt`: An `Option<&str>` containing the path to the SSL private key file.
+///
+/// # Returns
+///
+/// An `Option<RustlsConfig>`. `Some(RustlsConfig)` if TLS can be configured, `None` otherwise.
 pub async fn try_load_rustls_config(ssl_cert_path_opt: Option<&str>, ssl_key_path_opt: Option<&str>) -> Option<RustlsConfig> {
     // Check if both paths are provided
     let (cert_p, key_p) = match (ssl_cert_path_opt, ssl_key_path_opt) {
@@ -39,11 +55,21 @@ pub async fn try_load_rustls_config(ssl_cert_path_opt: Option<&str>, ssl_key_pat
     }
 }
 
-/// Parses a listen address string (e.g., "0.0.0.0:8080" or "0.0.0.0:8043 ssl").
+/// Parses a server listen address string to extract the address and SSL flag.
 ///
-/// Returns `Some((address_part, is_ssl))` if the string is valid,
-/// or `None` if the input string is empty.
-/// `is_ssl` is true if the string ends with " ssl".
+/// The input string can be in the format "IP:PORT" or "IP:PORT ssl".
+/// If the string ends with " ssl" (case-sensitive), the SSL flag is set to true.
+///
+/// # Arguments
+///
+/// * `listen_str`: A string slice (`&str`) representing the listen address configuration.
+///
+/// # Returns
+///
+/// An `Option<(String, bool)>`.
+/// - `Some((address, is_ssl))` where `address` is the IP:PORT part and `is_ssl`
+///   is true if " ssl" was present.
+/// - `None` if the input `listen_str` is empty.
 pub fn parse_listen_address(listen_str: &str) -> Option<(String, bool)> {
     if listen_str.is_empty() {
         return None;


### PR DESCRIPTION
The `/endpoints` route now includes entries for:
- `/swagger-ui` (GET): Displays the OpenAPI/Swagger UI.
- `/delay/:n` (ANY): Delays the response by 'n' seconds.

This makes these utility endpoints more discoverable.