### PR TITLE
feat: Add debian packaging for Ubuntu/Debian systems

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,3 +26,13 @@ utoipa-swagger-ui = { version = "7", features = ["axum"] }
 
 [dev-dependencies]
 tempfile = "3.8.0"
+
+[package.metadata.deb]
+maintainer = "Your Name <your.email@example.com>"
+copyright = "Your Name <your.email@example.com>"
+depends = "$auto"
+assets = [
+    ["target/release/rucho", "usr/bin/rucho", "755"],
+    ["config_samples/rucho.conf.default", "etc/rucho/rucho.conf.default", "644"],
+]
+features = []

--- a/README.md
+++ b/README.md
@@ -153,6 +153,22 @@ curl -i http://localhost:8080/status/503
 
 ---
 
+## Installation
+
+### From .deb package (for Ubuntu/Debian)
+
+1. Download the latest `.deb` package from the [releases page](https://github.com/user/repo/releases).
+2. Install the package using `dpkg`:
+   ```bash
+   sudo dpkg -i rucho_<version>_amd64.deb
+   ```
+   If you encounter any dependency issues, run:
+   ```bash
+   sudo apt-get install -f
+   ```
+
+---
+
 ## Configuration
 
 Rucho can be configured through configuration files and environment variables.


### PR DESCRIPTION
This commit introduces the capability to build a .deb package for `rucho`, facilitating easier installation on your Ubuntu and Debian-based systems.

Changes include:
- Added `[package.metadata.deb]` section to `Cargo.toml` with necessary package information and asset definitions.
- The build process now generates a `.deb` package in `target/debian/`.
- Updated `README.md` to include instructions for installing the application using the .deb package.

I tested the .deb package by installing it on an Ubuntu environment, verifying that the application runs and the default configuration file is correctly placed.