### PR TITLE
Fix: Specify libc6 version in Debian package metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ tempfile = "3.8.0"
 [package.metadata.deb]
 maintainer = "Your Name <your.email@example.com>"
 copyright = "Your Name <your.email@example.com>"
-depends = "$auto"
+depends = "libc6 (>= 2.35), $auto"
 assets = [
     ["target/release/rucho", "usr/bin/rucho", "755"],
     ["config_samples/rucho.conf.default", "etc/rucho/rucho.conf.default", "644"],


### PR DESCRIPTION
The `cargo-deb` tool was automatically determining the minimum required `libc6` version, leading to an overly restrictive dependency (>= 2.38). This commit explicitly sets the `libc6` dependency to `>= 2.35` in the `Cargo.toml` file's `[package.metadata.deb]` section. This allows the package to be installed on systems with `libc6` version 2.35 or newer, such as Ubuntu 22.04 LTS.