### PR TITLE
Fix: Ensure PID directory exists before creating PID file

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -133,6 +133,21 @@ async fn main() {
         CliCommand::Start {} => {
             tracing::info!("Starting server..."); // Changed from println!
             let pid = process::id();
+
+            // Create PID directory if it doesn't exist
+            let pid_dir = std::path::Path::new(PID_FILE).parent().unwrap();
+            if !pid_dir.exists() {
+                match fs::create_dir_all(&pid_dir) {
+                    Ok(_) => {
+                        tracing::info!("PID directory {} created", pid_dir.display());
+                    }
+                    Err(e) => {
+                        tracing::error!("Failed to create PID directory {}: {}", pid_dir.display(), e);
+                        // Continue to attempt PID file creation as per original logic
+                    }
+                }
+            }
+
             match fs::File::create(PID_FILE) {
                 Ok(mut file) => {
                     if let Err(e) = writeln!(file, "{}", pid) {


### PR DESCRIPTION
The `rucho start` command was failing to create the PID file if the directory `/var/run/rucho/` did not exist. This change modifies the startup process to:

1. Check if the PID directory (`/var/run/rucho/`) exists.
2. If it does not exist, attempt to create it using `std::fs::create_dir_all`.
3. Log an error if directory creation fails, but still attempt to create the PID file to maintain previous behavior in case of permission issues.

This resolves the issue where `rucho status` would report "PID file /var/run/rucho/rucho.pid not found" due to the directory not being present.