### PR TITLE
Feature/docker compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,22 @@ To run Rucho using Docker Compose:
 
 The server will be accessible at `http://localhost:8080` and `http://localhost:9090` (or as configured).
 
+You can also override configuration by setting environment variables within the `docker-compose.yml` file or by passing them on the command line. See the `environment` section in the `docker-compose.yml` for examples.
+
+For instance, to change the log level, you could uncomment and set `RUCHO_LOG_LEVEL` in the `docker-compose.yml`:
+```yaml
+services:
+  rucho:
+    # ... other configurations
+    environment:
+      RUCHO_LOG_LEVEL: "debug"
+      # RUCHO_SERVER_LISTEN_PRIMARY: "0.0.0.0:8000"
+```
+Or, you can pass environment variables when running `docker-compose up` (though this is less common for overriding file settings):
+```bash
+RUCHO_LOG_LEVEL=debug docker-compose up
+```
+
 To stop the services:
 ```bash
 docker-compose down

--- a/README.md
+++ b/README.md
@@ -153,6 +153,33 @@ curl -i http://localhost:8080/status/503
 
 ---
 
+## Running with Docker Compose
+
+To run Rucho using Docker Compose:
+
+1.  **Ensure Docker Compose is installed.**
+2.  **From the root of the project, run:**
+    ```bash
+    docker-compose up
+    ```
+    To run in detached mode:
+    ```bash
+    docker-compose up -d
+    ```
+    To rebuild the image before starting:
+    ```bash
+    docker-compose up --build
+    ```
+
+The server will be accessible at `http://localhost:8080` and `http://localhost:9090` (or as configured).
+
+To stop the services:
+```bash
+docker-compose down
+```
+
+---
+
 ## Configuration
 
 Rucho can be configured through configuration files and environment variables.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,9 +10,16 @@ services:
       - "9090:9090"
     volumes:
       - ./config_samples/rucho.conf.default:/etc/rucho/rucho.conf
+    environment:
+      # Uncomment and set these variables to override values from rucho.conf
+      # RUCHO_LOG_LEVEL: "debug"
+      # RUCHO_SERVER_LISTEN_PRIMARY: "0.0.0.0:8000"
+      # RUCHO_SERVER_LISTEN_SECONDARY: "0.0.0.0:9000"
+      # RUCHO_PREFIX: "/app/data"
     # If you need to persist data, uncomment the following lines and adjust the path
     # volumes:
     #   - rucho_data:/var/run/rucho
+
 # Volumes section (optional, if you need to persist data)
 # volumes:
 #   rucho_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,18 @@
+version: '3.8'
+
+services:
+  rucho:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - "8080:8080"
+      - "9090:9090"
+    volumes:
+      - ./config_samples/rucho.conf.default:/etc/rucho/rucho.conf
+    # If you need to persist data, uncomment the following lines and adjust the path
+    # volumes:
+    #   - rucho_data:/var/run/rucho
+# Volumes section (optional, if you need to persist data)
+# volumes:
+#   rucho_data:


### PR DESCRIPTION
Enhance Docker Compose with environment variable configuration

This commit updates the Docker Compose setup to allow users to configure Rucho via environment variables.

- Added an `environment` section to `docker-compose.yml` with example RUCHO_ variables.
- Updated `README.md` to explain how to use environment variables for configuration with Docker Compose.

####UPDATED^^^^^^^

Add Docker Compose support for Rucho server

This commit introduces a docker-compose.yml file to easily run the Rucho server in a containerized environment.

- Defines a 'rucho' service using the existing Dockerfile.
- Maps ports 8080 and 9090.
- Mounts the default configuration file.
- Updates README.md with instructions for Docker Compose usage.

