### PR TITLE
docs: Bump stale version refs to 1.4.6

### DIFF
--- a/debian/man/rucho.1
+++ b/debian/man/rucho.1
@@ -1,5 +1,5 @@
 .\" Man page for rucho(1)
-.TH RUCHO 1 "2026-02-16" "rucho 1.4.4" "Rucho Manual"
+.TH RUCHO 1 "2026-02-17" "rucho 1.4.6" "Rucho Manual"
 .SH NAME
 rucho \- HTTP echo server and request inspector
 .SH SYNOPSIS

--- a/docs/INTERNALS.md
+++ b/docs/INTERNALS.md
@@ -5,7 +5,7 @@
 > path in the codebase. It is intended as a developer reference — not user-facing
 > API docs.
 >
-> **Version:** 1.4.5
+> **Version:** 1.4.6
 > **Last updated:** 2026-02-17
 
 ---


### PR DESCRIPTION
## Summary
- Update INTERNALS.md version header: 1.4.5 → 1.4.6
- Update man page header: 1.4.4 → 1.4.6, date → 2026-02-17

## Test plan
- [x] Docs-only change, no code affected
- [x] Verified no other stale version refs remain (CHANGELOG/ROADMAP entries are historical)

🤖 Generated with [Claude Code](https://claude.com/claude-code)