### PR TITLE
feat: Add /base64/:encoded endpoint for decoding URL-safe base64

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `/base64/:encoded` endpoint — decode URL-safe base64 strings and return JSON with decoded content, UTF-8 validity, and byte length. Accepts URL-safe base64 with or without padding; standard base64 is attempted as a fallback. Input capped at 4096 bytes.
+
 ## [1.4.6] - 2026-02-17
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1970,6 +1970,7 @@ version = "1.4.6"
 dependencies = [
  "axum",
  "axum-server",
+ "base64 0.22.1",
  "clap",
  "criterion",
  "http",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ uuid = { version = "1", features = ["v4"] }
 rand = "0.8"
 socket2 = { version = "0.5", features = ["all"] }
 hyper-util = { version = "0.1", features = ["tokio"] }
+base64 = "0.22"
 
 [dev-dependencies]
 tempfile = "3.8.0"

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ rucho version  # Display version
 | GET     | `/cookies`        | Inspect request cookies                              |
 | GET     | `/cookies/set`    | Set cookies via query params and redirect            |
 | GET     | `/cookies/delete` | Delete cookies via query params and redirect         |
+| GET     | `/base64/:encoded`| Decode URL-safe base64 (max 4096 bytes)              |
 | GET     | `/uuid`           | Random UUID v4                                       |
 | GET     | `/ip`             | Client IP address                                    |
 | GET     | `/user-agent`     | User-Agent header echo                               |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -77,7 +77,7 @@
 - [ ] `/bearer` — test Bearer token auth (check `Authorization` header)
 
 ### Data Formats & Content Types
-- [ ] `/base64/:encoded` — decode base64 in the URL and return the result
+- [x] `/base64/:encoded` — decode base64 in the URL and return the result
 - [ ] `/bytes/:n` — return `n` random bytes (binary download testing)
 - [ ] `/xml`, `/html` — return non-JSON content types
 - [ ] `/image/:format` — return a small test image (png, jpeg, svg, webp)

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -15,6 +15,7 @@ Complete reference for all Rucho HTTP endpoints.
 - [Redirects](#redirects)
 - [Delay](#delay)
 - [Cookies](#cookies)
+- [Data Formats](#data-formats)
 - [Infrastructure](#infrastructure)
 - [Documentation](#documentation)
 
@@ -388,6 +389,51 @@ Each query parameter name identifies a cookie to expire. Values are ignored.
 curl -b "name=rucho" -c - http://localhost:8080/cookies/delete?name
 # Set-Cookie: name=; Max-Age=0; Path=/
 # Location: /cookies
+```
+
+---
+
+## Data Formats
+
+### GET /base64/:encoded
+
+Decodes a URL-safe base64-encoded string from the URL path and returns metadata about the result.
+
+**Path parameters:**
+
+| Name | Description |
+|------|-------------|
+| `encoded` | URL-safe base64-encoded string (max 4096 bytes). Padding is optional. Standard base64 is attempted as a fallback but won't tolerate `/` in the path. |
+
+**Response:** `200 OK`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `encoded` | string | The input base64 string (as received) |
+| `decoded` | string | The decoded content (via `String::from_utf8_lossy` — invalid UTF-8 bytes are replaced with `U+FFFD`) |
+| `is_utf8` | boolean | `true` if the raw decoded bytes are valid UTF-8 |
+| `byte_length` | number | Length of the decoded bytes |
+| `timing.duration_ms` | number | Processing time in milliseconds |
+
+**Errors:**
+
+- `400 Bad Request` — invalid base64 input
+- `400 Bad Request` — input exceeds the 4096-byte cap
+
+```json
+{
+  "encoded": "SGVsbG8sIFJ1Y2hvIQ==",
+  "decoded": "Hello, Rucho!",
+  "is_utf8": true,
+  "byte_length": 13,
+  "timing": {
+    "duration_ms": 0.041
+  }
+}
+```
+
+```bash
+curl http://localhost:8080/base64/SGVsbG8sIFJ1Y2hvIQ==
 ```
 
 ---

--- a/docs/USAGE_EXAMPLES.md
+++ b/docs/USAGE_EXAMPLES.md
@@ -21,6 +21,7 @@ All examples assume rucho is running at `http://localhost:8080` (the default).
 - [Redirect Testing](#redirect-testing)
 - [Delay & Timeout Testing](#delay--timeout-testing)
 - [Cookie Management](#cookie-management)
+- [Base64 Decoding](#base64-decoding)
 - [Chaos Engineering](#chaos-engineering)
 - [Health Checks & Monitoring](#health-checks--monitoring)
 
@@ -697,6 +698,85 @@ const inspectResp = await fetch("http://localhost:8080/cookies", {
 });
 const data = await inspectResp.json();
 console.log("Cookies:", data.cookies);
+```
+
+---
+
+## Base64 Decoding
+
+Decode a URL-safe base64 string from the URL path. Useful for inspecting encoded tokens, data URIs, or any opaque payload a client is about to send through a gateway. Returns a JSON wrapper with the decoded content, a UTF-8 validity flag, and the byte length — so you can tell textual payloads apart from binary blobs.
+
+Input is capped at 4096 bytes. URL-safe alphabet (`-`, `_`) with or without padding is preferred; standard base64 is attempted as a fallback but `/` in the encoding will break path routing.
+
+### Decode a UTF-8 string
+
+**curl:**
+
+```bash
+curl http://localhost:8080/base64/SGVsbG8sIFJ1Y2hvIQ==
+```
+
+**Python:**
+
+```python
+import base64, requests
+
+text = "Hello, Rucho!"
+encoded = base64.urlsafe_b64encode(text.encode()).decode()
+resp = requests.get(f"http://localhost:8080/base64/{encoded}")
+print(resp.json())
+```
+
+**JavaScript:**
+
+```javascript
+const text = "Hello, Rucho!";
+const encoded = Buffer.from(text).toString("base64url");
+const resp = await fetch(`http://localhost:8080/base64/${encoded}`);
+console.log(await resp.json());
+```
+
+**Sample response:**
+
+```json
+{
+  "encoded": "SGVsbG8sIFJ1Y2hvIQ==",
+  "decoded": "Hello, Rucho!",
+  "is_utf8": true,
+  "byte_length": 13,
+  "timing": {
+    "duration_ms": 0.041
+  }
+}
+```
+
+### Detect binary (non-UTF-8) payloads
+
+Encoded bytes that aren't valid UTF-8 are still returned (with lossy replacement), but `is_utf8` will be `false` so clients can branch on it:
+
+```bash
+# Encodes bytes [0xFF, 0xFE, 0xFD] — a non-UTF-8 sequence
+curl http://localhost:8080/base64/__79
+```
+
+```json
+{
+  "encoded": "__79",
+  "decoded": "���",
+  "is_utf8": false,
+  "byte_length": 3,
+  "timing": { "duration_ms": 0.018 }
+}
+```
+
+### Error cases
+
+```bash
+# Invalid base64 — returns 400
+curl -i http://localhost:8080/base64/a
+
+# Input exceeds 4096-byte cap — returns 400
+curl -i "http://localhost:8080/base64/$(python3 -c 'print("A"*4097)')"
 ```
 
 ---

--- a/src/main.rs
+++ b/src/main.rs
@@ -51,6 +51,7 @@ use rucho::utils::metrics::Metrics;
         rucho::routes::cookies::cookies_handler,
         rucho::routes::cookies::set_cookies_handler,
         rucho::routes::cookies::delete_cookies_handler,
+        rucho::routes::base64::base64_handler,
         rucho::routes::core_routes::uuid_handler,
         rucho::routes::core_routes::ip_handler,
         rucho::routes::core_routes::user_agent_handler,
@@ -143,7 +144,8 @@ fn build_app(
         .merge(rucho::routes::healthz::router())
         .merge(rucho::routes::delay::router())
         .merge(rucho::routes::redirect::router())
-        .merge(rucho::routes::cookies::router());
+        .merge(rucho::routes::cookies::router())
+        .merge(rucho::routes::base64::router());
 
     // Add metrics endpoint and middleware if enabled
     if let Some(metrics) = metrics {

--- a/src/routes/base64.rs
+++ b/src/routes/base64.rs
@@ -1,0 +1,184 @@
+//! Base64 decoding endpoint.
+//!
+//! Decodes a URL-safe base64-encoded string from the URL path and returns the
+//! decoded content along with metadata (UTF-8 validity, byte length). Accepts
+//! URL-safe base64 with or without padding; standard base64 is also attempted
+//! as a fallback but will not tolerate `/` in the path segment.
+
+use axum::{extract::Path, http::StatusCode, response::Response, routing::get, Extension, Router};
+use base64::Engine;
+use serde_json::json;
+
+use crate::utils::{
+    constants::MAX_BASE64_INPUT_BYTES, error_response::format_error_response,
+    json_response::format_json_response_with_timing, timing::RequestTiming,
+};
+
+/// Handles requests to the `/base64/:encoded` endpoint.
+///
+/// Decodes the URL-path base64 string and returns a JSON payload with the
+/// decoded content, a UTF-8 validity flag, and the decoded byte length.
+///
+/// # Security
+///
+/// Input is capped at `MAX_BASE64_INPUT_BYTES` (4096 bytes) to prevent
+/// denial-of-service attacks from oversized decode operations.
+///
+/// # Path Parameters
+///
+/// - `encoded`: The base64-encoded string to decode. URL-safe alphabet is
+///   preferred; padding is optional.
+///
+/// # Responses
+///
+/// - `200 OK`: JSON object with `encoded`, `decoded`, `is_utf8`, `byte_length`,
+///   and `timing.duration_ms`.
+/// - `400 Bad Request`: Invalid base64 input or input exceeds the size limit.
+#[utoipa::path(
+    get,
+    path = "/base64/{encoded}",
+    params(
+        ("encoded" = String, Path, description = "URL-safe base64-encoded string to decode (max 4096 bytes)")
+    ),
+    responses(
+        (status = 200, description = "Returns decoded content with metadata", body = serde_json::Value),
+        (status = 400, description = "Invalid base64 input or input exceeds size limit")
+    )
+)]
+pub async fn base64_handler(
+    Path(encoded): Path<String>,
+    timing: Option<Extension<RequestTiming>>,
+) -> Response {
+    if encoded.len() > MAX_BASE64_INPUT_BYTES {
+        return format_error_response(
+            StatusCode::BAD_REQUEST,
+            &format!(
+                "Base64 input of {} bytes exceeds maximum allowed value of {} bytes",
+                encoded.len(),
+                MAX_BASE64_INPUT_BYTES
+            ),
+        );
+    }
+
+    // Try URL-safe variants first (expected for URL paths), then standard as fallback.
+    let decoded_bytes = base64::engine::general_purpose::URL_SAFE
+        .decode(&encoded)
+        .or_else(|_| base64::engine::general_purpose::URL_SAFE_NO_PAD.decode(&encoded))
+        .or_else(|_| base64::engine::general_purpose::STANDARD.decode(&encoded))
+        .or_else(|_| base64::engine::general_purpose::STANDARD_NO_PAD.decode(&encoded));
+
+    match decoded_bytes {
+        Ok(bytes) => {
+            let is_utf8 = std::str::from_utf8(&bytes).is_ok();
+            let decoded = String::from_utf8_lossy(&bytes).into_owned();
+            let byte_length = bytes.len();
+
+            let payload = json!({
+                "encoded": encoded,
+                "decoded": decoded,
+                "is_utf8": is_utf8,
+                "byte_length": byte_length,
+            });
+
+            let duration_ms = timing.map(|t| t.elapsed_ms());
+            format_json_response_with_timing(payload, duration_ms)
+        }
+        Err(_) => format_error_response(StatusCode::BAD_REQUEST, "Invalid base64 input"),
+    }
+}
+
+/// Creates and returns the Axum router for the base64 decoding endpoint.
+pub fn router() -> Router {
+    Router::new().route("/base64/:encoded", get(base64_handler))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::body::Body;
+    use axum::http::Request;
+    use tower::ServiceExt;
+
+    async fn body_json(resp: Response) -> serde_json::Value {
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        serde_json::from_slice(&body).unwrap()
+    }
+
+    #[tokio::test]
+    async fn test_decode_url_safe_with_padding() {
+        // "Hello, Rucho!" -> SGVsbG8sIFJ1Y2hvIQ==
+        let response = router()
+            .oneshot(
+                Request::get("/base64/SGVsbG8sIFJ1Y2hvIQ==")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let json = body_json(response).await;
+        assert_eq!(json["encoded"], "SGVsbG8sIFJ1Y2hvIQ==");
+        assert_eq!(json["decoded"], "Hello, Rucho!");
+        assert_eq!(json["is_utf8"], true);
+        assert_eq!(json["byte_length"], 13);
+    }
+
+    #[tokio::test]
+    async fn test_decode_url_safe_without_padding() {
+        let response = router()
+            .oneshot(
+                Request::get("/base64/SGVsbG8sIFJ1Y2hvIQ")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let json = body_json(response).await;
+        assert_eq!(json["decoded"], "Hello, Rucho!");
+    }
+
+    #[tokio::test]
+    async fn test_decode_non_utf8_marked_false() {
+        // URL-safe encoding of [0xFF, 0xFE, 0xFD] => "__79"
+        let response = router()
+            .oneshot(Request::get("/base64/__79").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let json = body_json(response).await;
+        assert_eq!(json["is_utf8"], false);
+        assert_eq!(json["byte_length"], 3);
+    }
+
+    #[tokio::test]
+    async fn test_invalid_base64_returns_400() {
+        // Length-1 input is invalid for every base64 variant.
+        let response = router()
+            .oneshot(Request::get("/base64/a").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn test_oversized_input_returns_400() {
+        let oversized: String = "A".repeat(MAX_BASE64_INPUT_BYTES + 1);
+        let response = router()
+            .oneshot(
+                Request::get(format!("/base64/{}", oversized).as_str())
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    }
+}

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -2,11 +2,14 @@
 //!
 //! This module contains all the HTTP route handlers organized into submodules:
 //!
+//! - [`base64`] - Base64 decoding endpoint
 //! - [`cookies`] - Cookie inspection and manipulation endpoints
 //! - [`core_routes`] - Main API endpoints (GET, POST, PUT, PATCH, DELETE, etc.)
 //! - [`delay`] - Delay endpoint for testing timeouts
 //! - [`healthz`] - Health check endpoint
 
+/// Module for the base64 decoding endpoint (`/base64/:encoded`).
+pub mod base64;
 /// Module for the cookie inspection and manipulation endpoints (`/cookies`).
 pub mod cookies;
 /// Module for core API routes, including various HTTP method handlers and utility endpoints.

--- a/src/utils/constants.rs
+++ b/src/utils/constants.rs
@@ -26,6 +26,10 @@ pub const MAX_DELAY_SECONDS: u64 = 300;
 /// This prevents abuse through excessively long redirect chains.
 pub const MAX_REDIRECT_HOPS: u32 = 20;
 
+/// Maximum length in bytes for the encoded input to the `/base64/:encoded` endpoint.
+/// This prevents DoS from oversized decode operations on the path segment.
+pub const MAX_BASE64_INPUT_BYTES: usize = 4096;
+
 /// Maximum buffer size in bytes for TCP/UDP connections.
 /// This prevents memory exhaustion from malicious large payloads.
 pub const MAX_BUFFER_SIZE: usize = 65536;

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -5,7 +5,7 @@
 //! actual TCP connections.
 
 use axum::{middleware, Router};
-use rucho::routes::{cookies, core_routes, delay, healthz, redirect};
+use rucho::routes::{base64, cookies, core_routes, delay, healthz, redirect};
 use rucho::server::timing_layer::timing_middleware;
 
 /// Spawns a test server on a random port and returns its base URL.
@@ -22,6 +22,7 @@ async fn spawn_app() -> String {
         .merge(delay::router())
         .merge(redirect::router())
         .merge(cookies::router())
+        .merge(base64::router())
         .layer(middleware::from_fn(timing_middleware));
 
     tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
@@ -194,6 +195,29 @@ async fn test_cookies_roundtrip() {
 
     let body: serde_json::Value = resp.json().await.unwrap();
     assert_eq!(body["cookies"]["foo"], "bar");
+}
+
+#[tokio::test]
+async fn test_base64_decode() {
+    let base = spawn_app().await;
+    // "Hello, Rucho!" -> SGVsbG8sIFJ1Y2hvIQ==
+    let resp = reqwest::get(format!("{base}/base64/SGVsbG8sIFJ1Y2hvIQ=="))
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), 200);
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(body["decoded"], "Hello, Rucho!");
+    assert_eq!(body["is_utf8"], true);
+    assert_eq!(body["byte_length"], 13);
+}
+
+#[tokio::test]
+async fn test_base64_invalid_returns_400() {
+    let base = spawn_app().await;
+    let resp = reqwest::get(format!("{base}/base64/a")).await.unwrap();
+
+    assert_eq!(resp.status(), 400);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- Adds `GET /base64/:encoded` — decodes URL-safe base64 from the path and returns JSON with `encoded`, `decoded`, `is_utf8`, `byte_length`, and `timing.duration_ms`
- Accepts URL-safe base64 with or without padding; standard base64 is attempted as a fallback (won't tolerate `/` in the path)
- Input capped at 4096 bytes via new `MAX_BASE64_INPUT_BYTES` constant — returns 400 on oversized or invalid input
- Binary payloads still come back via `String::from_utf8_lossy` with `is_utf8: false` as a client-side signal

## Test plan
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] 90 unit tests pass (5 new for base64: padded, unpadded, non-UTF-8, invalid, oversized)
- [x] 14 integration tests pass (2 new: successful decode + 400 on invalid)
- [ ] Spot-check in browser via `/swagger-ui` after merge
- [ ] `curl http://localhost:8080/base64/SGVsbG8sIFJ1Y2hvIQ==` returns the expected JSON

Closes the `/base64/:encoded` item under Tier 3: New Endpoints in ROADMAP.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)