### PR TITLE
docs: Update project-structure blocks for base64 endpoint

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -147,6 +147,7 @@ src/
 │   └── commands.rs      # start, stop, status, version handlers
 ├── routes/              # HTTP route handlers
 │   ├── mod.rs
+│   ├── base64.rs        # /base64/:encoded endpoint
 │   ├── cookies.rs       # /cookies endpoints
 │   ├── core_routes.rs   # Core echo + utility endpoints
 │   ├── delay.rs         # /delay/:n endpoint

--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ src/
 │   └── commands.rs      # start, stop, status, version handlers
 ├── routes/              # HTTP route handlers
 │   ├── mod.rs
+│   ├── base64.rs        # /base64/:encoded endpoint
 │   ├── cookies.rs       # /cookies endpoints
 │   ├── core_routes.rs   # Core echo + utility endpoints
 │   ├── delay.rs         # /delay/:n endpoint

--- a/docs/INTERNALS.md
+++ b/docs/INTERNALS.md
@@ -82,6 +82,7 @@ rucho (crate root)
   |
   +-- routes/                # HTTP route handlers
   |   +-- mod.rs             # Re-exports submodules
+  |   +-- base64.rs          # /base64/:encoded handler + router()
   |   +-- cookies.rs         # /cookies, /cookies/set, /cookies/delete handlers + router()
   |   +-- core_routes.rs     # 16 route handlers + router()
   |   +-- delay.rs           # /delay/:n handler + router()
@@ -621,6 +622,7 @@ The response travels back up through each middleware layer:
 | 22 | `/cookies` | GET | `cookies_handler` | `cookies.rs:60` |
 | 23 | `/cookies/set` | GET | `set_cookies_handler` | `cookies.rs:88` |
 | 24 | `/cookies/delete` | GET | `delete_cookies_handler` | `cookies.rs:121` |
+| 25 | `/base64/:encoded` | GET | `base64_handler` | `base64.rs:48` |
 
 ### 5.2 Echo Handlers
 
@@ -2274,6 +2276,7 @@ Complete listing of all source files with line counts and primary purpose:
 | `src/cli/mod.rs` | CLI module re-exports |
 | `src/cli/commands.rs` | `Args`, `CliCommand`, start/stop/status/version handlers |
 | `src/routes/mod.rs` | Routes module re-exports |
+| `src/routes/base64.rs` | `/base64/:encoded` handler and router |
 | `src/routes/cookies.rs` | `/cookies`, `/cookies/set`, `/cookies/delete` handlers and router |
 | `src/routes/core_routes.rs` | 16 route handlers, `router()`, `EndpointInfo`, `API_ENDPOINTS` |
 | `src/routes/delay.rs` | `/delay/:n` handler and router |


### PR DESCRIPTION
## Summary
- Adds `src/routes/base64.rs` to the project-structure trees in `README.md`, `CONTRIBUTING.md`, and `docs/INTERNALS.md`
- Adds `/base64/:encoded` as entry #25 in the INTERNALS endpoint summary table
- Adds `src/routes/base64.rs` to the INTERNALS source file index
- Housekeeping pass after PR #105 shipped the endpoint — keeps the three project-structure blocks consistent with each other until the roadmap's doc-consolidation item (Tier 7) collapses them to a single canonical source

## Test plan
- [ ] Render README, CONTRIBUTING, and INTERNALS on GitHub and confirm `base64.rs` appears in each tree
- [ ] Confirm INTERNALS endpoint table has 25 rows and no line-ref drift was introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)