### PR TITLE
fix: Cap /anything request body size via DefaultBodyLimit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - `/base64/:encoded` endpoint — decode URL-safe base64 strings and return JSON with decoded content, UTF-8 validity, and byte length. Accepts URL-safe base64 with or without padding; standard base64 is attempted as a fallback. Input capped at 4096 bytes.
+- `max_body_size_bytes` config field (env: `RUCHO_MAX_BODY_SIZE_BYTES`, default: 2 MiB) — caps request body size globally via `DefaultBodyLimit`. Requests exceeding the limit receive 413 Payload Too Large.
+
+### Fixed
+- `/anything` handler no longer reads the full request body with `usize::MAX` limit — closes an OOM vector. `anything_handler` now uses the `Bytes` extractor which honors the configured `max_body_size_bytes`.
 
 ## [1.4.6] - 2026-02-17
 

--- a/config_samples/rucho.conf.default
+++ b/config_samples/rucho.conf.default
@@ -74,6 +74,12 @@ compression_enabled = false
 # Protects against slowloris-style attacks.
 # Default: 30
 # header_read_timeout = 30
+#
+# Maximum request body size in bytes. Requests exceeding this return 413
+# Payload Too Large. Protects against OOM from unbounded bodies to /anything
+# and other body-accepting handlers.
+# Default: 2097152 (2 MiB)
+# max_body_size_bytes = 2097152
 
 # --- Chaos Engineering Mode ---
 # Chaos mode injects random failures, delays, and response corruption

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,7 @@
 //! This is the main entry point for the Rucho application. It handles CLI argument
 //! parsing and dispatches to the appropriate command handlers.
 
-use axum::{middleware, routing::get, Router};
+use axum::{extract::DefaultBodyLimit, middleware, routing::get, Router};
 use clap::Parser;
 use std::str::FromStr;
 use std::sync::Arc;
@@ -118,7 +118,12 @@ async fn main() {
                 }
 
                 let chaos = Arc::new(config.chaos.clone());
-                let app = build_app(metrics, config.compression_enabled, chaos);
+                let app = build_app(
+                    metrics,
+                    config.compression_enabled,
+                    chaos,
+                    config.max_body_size_bytes,
+                );
                 rucho::server::run_server(&config, app).await;
             }
         }
@@ -133,10 +138,13 @@ async fn main() {
 /// If metrics is Some, enables the /metrics endpoint and metrics collection middleware.
 /// If compression_enabled is true, enables gzip/brotli response compression.
 /// If chaos mode is enabled, adds chaos middleware for resilience testing.
+/// `max_body_size_bytes` caps request body size via `DefaultBodyLimit`; requests
+/// with larger bodies receive 413 Payload Too Large.
 fn build_app(
     metrics: Option<Arc<Metrics>>,
     compression_enabled: bool,
     chaos: Arc<ChaosConfig>,
+    max_body_size_bytes: usize,
 ) -> Router {
     let mut app = Router::new()
         .merge(SwaggerUi::new("/swagger-ui").url("/api-docs/openapi.json", ApiDoc::openapi()))
@@ -145,7 +153,8 @@ fn build_app(
         .merge(rucho::routes::delay::router())
         .merge(rucho::routes::redirect::router())
         .merge(rucho::routes::cookies::router())
-        .merge(rucho::routes::base64::router());
+        .merge(rucho::routes::base64::router())
+        .layer(DefaultBodyLimit::max(max_body_size_bytes));
 
     // Add metrics endpoint and middleware if enabled
     if let Some(metrics) = metrics {

--- a/src/routes/core_routes.rs
+++ b/src/routes/core_routes.rs
@@ -1,6 +1,5 @@
 use crate::utils::{
-    error_response::format_error_response,
-    json_response::{format_json_response, format_json_response_with_timing},
+    error_response::format_error_response, json_response::format_json_response_with_timing,
     timing::RequestTiming,
 };
 use axum::{
@@ -300,19 +299,14 @@ pub async fn anything_handler(
     axum::extract::OriginalUri(uri): axum::extract::OriginalUri,
     headers: HeaderMap,
     timing: Option<Extension<RequestTiming>>,
-    body: axum::body::Body,
+    body: axum::body::Bytes,
 ) -> impl IntoResponse {
-    let body_bytes = match axum::body::to_bytes(body, usize::MAX).await {
-        Ok(bytes) => bytes,
-        Err(_) => return format_json_response(json!({"error": "Failed to read body"})),
-    };
-
     let resp = json!({
         "method": method.to_string(),
         "path": uri.path(),
         "query": uri.query().unwrap_or(""),
         "headers": serialize_headers(&headers),
-        "body": String::from_utf8_lossy(&body_bytes),
+        "body": String::from_utf8_lossy(&body),
     });
 
     let duration_ms = timing.map(|t| t.elapsed_ms());

--- a/src/utils/config.rs
+++ b/src/utils/config.rs
@@ -4,8 +4,9 @@ use std::path::PathBuf;
 
 use crate::utils::constants::{
     DEFAULT_HEADER_READ_TIMEOUT_SECS, DEFAULT_HTTP_KEEP_ALIVE_TIMEOUT_SECS, DEFAULT_LOG_LEVEL,
-    DEFAULT_PREFIX, DEFAULT_SERVER_LISTEN_PRIMARY, DEFAULT_SERVER_LISTEN_SECONDARY,
-    DEFAULT_TCP_KEEPALIVE_INTERVAL_SECS, DEFAULT_TCP_KEEPALIVE_RETRIES, DEFAULT_TCP_KEEPALIVE_SECS,
+    DEFAULT_MAX_BODY_SIZE_BYTES, DEFAULT_PREFIX, DEFAULT_SERVER_LISTEN_PRIMARY,
+    DEFAULT_SERVER_LISTEN_SECONDARY, DEFAULT_TCP_KEEPALIVE_INTERVAL_SECS,
+    DEFAULT_TCP_KEEPALIVE_RETRIES, DEFAULT_TCP_KEEPALIVE_SECS,
 };
 
 /// Configuration for chaos engineering mode.
@@ -108,6 +109,13 @@ macro_rules! load_env_var {
             }
         }
     };
+    ($config:expr, $field:ident, $env_var:expr, $env_reader:expr, usize) => {
+        if let Ok(value) = $env_reader($env_var) {
+            if let Ok(v) = value.parse::<usize>() {
+                $config.$field = v;
+            }
+        }
+    };
 }
 
 /// Holds the application configuration.
@@ -155,6 +163,9 @@ pub struct Config {
     pub tcp_nodelay: bool,
     /// Maximum time in seconds to wait for request headers from a client.
     pub header_read_timeout: u64,
+    /// Maximum request body size in bytes. Enforced globally via `DefaultBodyLimit`.
+    /// Requests with bodies larger than this receive a 413 Payload Too Large response.
+    pub max_body_size_bytes: usize,
     /// Chaos engineering configuration.
     pub chaos: ChaosConfig,
 }
@@ -180,6 +191,7 @@ impl Default for Config {
             tcp_keepalive_retries: DEFAULT_TCP_KEEPALIVE_RETRIES,
             tcp_nodelay: true,
             header_read_timeout: DEFAULT_HEADER_READ_TIMEOUT_SECS,
+            max_body_size_bytes: DEFAULT_MAX_BODY_SIZE_BYTES,
             chaos: ChaosConfig::default(),
         }
     }
@@ -277,6 +289,11 @@ impl Config {
                     "header_read_timeout" => {
                         if let Ok(v) = value.parse::<u64>() {
                             config.header_read_timeout = v;
+                        }
+                    }
+                    "max_body_size_bytes" => {
+                        if let Ok(v) = value.parse::<usize>() {
+                            config.max_body_size_bytes = v;
                         }
                     }
                     "chaos_mode" => {
@@ -458,6 +475,13 @@ impl Config {
             env_reader,
             u64
         );
+        load_env_var!(
+            config,
+            max_body_size_bytes,
+            "RUCHO_MAX_BODY_SIZE_BYTES",
+            env_reader,
+            usize
+        );
 
         // Chaos mode env vars (manual parsing since macro doesn't support nested fields)
         if let Ok(value) = env_reader("RUCHO_CHAOS_MODE") {
@@ -563,6 +587,11 @@ impl Config {
         if self.header_read_timeout == 0 {
             return Err(ConfigValidationError::Connection(
                 "header_read_timeout must be greater than 0".to_string(),
+            ));
+        }
+        if self.max_body_size_bytes == 0 {
+            return Err(ConfigValidationError::Connection(
+                "max_body_size_bytes must be greater than 0".to_string(),
             ));
         }
         Ok(())

--- a/src/utils/constants.rs
+++ b/src/utils/constants.rs
@@ -30,6 +30,11 @@ pub const MAX_REDIRECT_HOPS: u32 = 20;
 /// This prevents DoS from oversized decode operations on the path segment.
 pub const MAX_BASE64_INPUT_BYTES: usize = 4096;
 
+/// Default maximum request body size in bytes (2 MiB).
+/// Enforced globally via `DefaultBodyLimit` and applies to all extractor-based
+/// handlers, including `anything_handler`. Protects against OOM from unbounded bodies.
+pub const DEFAULT_MAX_BODY_SIZE_BYTES: usize = 2 * 1024 * 1024;
+
 /// Maximum buffer size in bytes for TCP/UDP connections.
 /// This prevents memory exhaustion from malicious large payloads.
 pub const MAX_BUFFER_SIZE: usize = 65536;

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -4,15 +4,21 @@
 //! `reqwest`, validating status codes, headers, and response bodies over
 //! actual TCP connections.
 
-use axum::{middleware, Router};
+use axum::{extract::DefaultBodyLimit, middleware, Router};
 use rucho::routes::{base64, cookies, core_routes, delay, healthz, redirect};
 use rucho::server::timing_layer::timing_middleware;
+use rucho::utils::constants::DEFAULT_MAX_BODY_SIZE_BYTES;
 
 /// Spawns a test server on a random port and returns its base URL.
 ///
 /// Builds a minimal Router (no chaos, metrics, tracing, or swagger) and
 /// serves it on `127.0.0.1:0` so each test gets its own isolated server.
 async fn spawn_app() -> String {
+    spawn_app_with_body_limit(DEFAULT_MAX_BODY_SIZE_BYTES).await
+}
+
+/// Variant of `spawn_app` that caps request bodies at `max_body_size` bytes.
+async fn spawn_app_with_body_limit(max_body_size: usize) -> String {
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();
 
@@ -23,6 +29,7 @@ async fn spawn_app() -> String {
         .merge(redirect::router())
         .merge(cookies::router())
         .merge(base64::router())
+        .layer(DefaultBodyLimit::max(max_body_size))
         .layer(middleware::from_fn(timing_middleware));
 
     tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
@@ -234,4 +241,19 @@ async fn test_anything_wildcard() {
     let body: serde_json::Value = resp.json().await.unwrap();
     assert_eq!(body["method"], "POST");
     assert_eq!(body["path"], "/anything/foo/bar");
+}
+
+#[tokio::test]
+async fn test_anything_body_limit_returns_413() {
+    let base = spawn_app_with_body_limit(1024).await;
+    let client = reqwest::Client::new();
+    let big_body = vec![b'x'; 2048];
+    let resp = client
+        .post(format!("{base}/anything"))
+        .body(big_body)
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), 413);
 }


### PR DESCRIPTION
## Summary
- Closes the OOM vector in `anything_handler` where `to_bytes(body, usize::MAX)` allowed unbounded request bodies
- Swaps the raw `axum::body::Body` extractor for `axum::body::Bytes`, which respects the `DefaultBodyLimit` middleware — Axum returns 413 Payload Too Large automatically when the cap is exceeded
- Wires a global `DefaultBodyLimit::max(max_body_size_bytes)` layer in `build_app()` so every body-reading extractor benefits
- Adds `max_body_size_bytes` config field (env: `RUCHO_MAX_BODY_SIZE_BYTES`, default 2 MiB) with file parsing, env override, and validation (`>0`)
- Updates `config_samples/rucho.conf.default` and `CHANGELOG.md`

## Test plan
- [x] `cargo fmt` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo test` — 90 unit + 15 integration + 1 doc test pass, including new `test_anything_body_limit_returns_413`
- [x] New test uses `spawn_app_with_body_limit(1024)` helper and asserts a 2 KiB POST to `/anything` returns 413

🤖 Generated with [Claude Code](https://claude.com/claude-code)