### PR TITLE
fix: Fall back to peer address for /ip when no forwarding header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - `/anything` handler no longer reads the full request body with `usize::MAX` limit — closes an OOM vector. `anything_handler` now uses the `Bytes` extractor which honors the configured `max_body_size_bytes`.
+- `/ip` no longer returns `"unknown"` when a request arrives without `X-Forwarded-For` or `X-Real-IP` headers. The server now binds with `into_make_service_with_connect_info::<SocketAddr>()`, letting `ip_handler` fall back to the peer address from the TCP connection.
 
 ## [1.4.6] - 2026-02-17
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -91,7 +91,7 @@
 - [ ] `/links/:n` — return an HTML page with `n` links (crawler testing)
 
 ### Endpoint Enhancements (from review)
-- [ ] `/ip` peer-address fallback via `ConnectInfo<SocketAddr>` — currently returns `"unknown"` when no `X-Forwarded-For` / `X-Real-IP` header is present (`src/routes/core_routes.rs`)
+- [x] `/ip` peer-address fallback via `ConnectInfo<SocketAddr>` — previously returned `"unknown"` when no `X-Forwarded-For` / `X-Real-IP` header was present. Server now binds with `into_make_service_with_connect_info::<SocketAddr>()` so `ip_handler` can read the peer IP from the TCP connection. (PR #111)
 - [ ] `/status/:code` should return the canonical reason phrase in the body (e.g., `"Not Found"` for 404) — matches httpbin behavior
 - [ ] `/redirect/:n` should emit an `X-Redirect-Count` header so clients can observe hop number without parsing the URL
 - [ ] `/cookies/set` should accept cookie attribute flags (`secure`, `httponly`, `samesite`, `max_age`) via query params for richer auth/session testing
@@ -252,14 +252,13 @@
 
 Ranked by payoff-per-hour from the review:
 
-1. **`/ip` peer-address fallback** — fixes a real correctness surprise, ~15 lines
-2. **Prometheus metrics format** — unlocks Grafana dashboards, pairs naturally with Kong's Prom plugin
-3. **`/response-headers` + `/bytes` + `/drip`** — highest-ROI roadmap endpoints for exercising gateway plugins (response-transformer, request-size-limiting, timeout policy)
-4. **`cargo audit` + Dependabot in CI** — supply-chain hygiene, trivial to add
-5. **CI matrix adds `windows-latest`** — prevents the WSL-dev drift the memory flags
-6. **Multi-arch Docker image** — small CI change, big UX win for Mac users
-7. **Metrics lock contention (DashMap / sharded atomics)** — only matters past ~10k rps; do it when benchmarks say so
-8. **Handler boilerplate DRY** — optional; the current "deferred" decision is defensible
+1. **Prometheus metrics format** — unlocks Grafana dashboards, pairs naturally with Kong's Prom plugin
+2. **`/response-headers` + `/bytes` + `/drip`** — highest-ROI roadmap endpoints for exercising gateway plugins (response-transformer, request-size-limiting, timeout policy)
+3. **`cargo audit` + Dependabot in CI** — supply-chain hygiene, trivial to add
+4. **CI matrix adds `windows-latest`** — prevents the WSL-dev drift the memory flags
+5. **Multi-arch Docker image** — small CI change, big UX win for Mac users
+6. **Metrics lock contention (DashMap / sharded atomics)** — only matters past ~10k rps; do it when benchmarks say so
+7. **Handler boilerplate DRY** — optional; the current "deferred" decision is defensible
 
 ---
 

--- a/src/routes/core_routes.rs
+++ b/src/routes/core_routes.rs
@@ -500,7 +500,11 @@ pub async fn uuid_handler(timing: Option<Extension<RequestTiming>>) -> Response 
         (status = 200, description = "Returns the client's IP address", body = serde_json::Value)
     )
 )]
-pub async fn ip_handler(headers: HeaderMap, timing: Option<Extension<RequestTiming>>) -> Response {
+pub async fn ip_handler(
+    headers: HeaderMap,
+    connect_info: Option<axum::extract::ConnectInfo<std::net::SocketAddr>>,
+    timing: Option<Extension<RequestTiming>>,
+) -> Response {
     // Try X-Forwarded-For first (common for proxied requests)
     let origin = headers
         .get("x-forwarded-for")
@@ -513,7 +517,9 @@ pub async fn ip_handler(headers: HeaderMap, timing: Option<Extension<RequestTimi
                 .and_then(|v| v.to_str().ok())
                 .map(|s| s.to_string())
         })
-        // Default if no headers present
+        // Fall back to the actual peer address from the TCP connection
+        .or_else(|| connect_info.map(|ci| ci.0.ip().to_string()))
+        // Last resort if the server wasn't bound with ConnectInfo
         .unwrap_or_else(|| "unknown".to_string());
 
     let duration_ms = timing.map(|t| t.elapsed_ms());

--- a/src/server/http.rs
+++ b/src/server/http.rs
@@ -120,7 +120,9 @@ async fn setup_http_listener(
                 tracing::info!("Starting HTTP server on http://{}", sock_addr);
                 let mut server = axum_server::Server::from_tcp(std_listener);
                 configure_http_builder(&mut server, config);
-                let server_future = server.handle(handle).serve(app.into_make_service());
+                let server_future = server
+                    .handle(handle)
+                    .serve(app.into_make_service_with_connect_info::<std::net::SocketAddr>());
                 server_handles.push(tokio::spawn(server_future));
             }
             Err(e) => {
@@ -159,7 +161,9 @@ async fn setup_https_listener(
             tracing::info!("Starting HTTPS server on https://{}", sock_addr);
             let mut server = axum_server::bind_rustls(sock_addr, rustls_config);
             configure_http_builder(&mut server, config);
-            let server_future = server.handle(handle).serve(app.into_make_service());
+            let server_future = server
+                .handle(handle)
+                .serve(app.into_make_service_with_connect_info::<std::net::SocketAddr>());
             server_handles.push(tokio::spawn(server_future));
         }
         None => {

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -32,7 +32,14 @@ async fn spawn_app_with_body_limit(max_body_size: usize) -> String {
         .layer(DefaultBodyLimit::max(max_body_size))
         .layer(middleware::from_fn(timing_middleware));
 
-    tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+    tokio::spawn(async move {
+        axum::serve(
+            listener,
+            app.into_make_service_with_connect_info::<std::net::SocketAddr>(),
+        )
+        .await
+        .unwrap()
+    });
 
     format!("http://{addr}")
 }
@@ -114,7 +121,30 @@ async fn test_ip() {
 
     assert_eq!(resp.status(), 200);
     let body: serde_json::Value = resp.json().await.unwrap();
-    assert!(body["origin"].is_string());
+    let origin = body["origin"].as_str().expect("origin should be a string");
+    // With ConnectInfo fallback, the peer address (127.0.0.1 or ::1) should
+    // appear even when no X-Forwarded-For / X-Real-IP header is set.
+    assert_ne!(origin, "unknown", "origin should fall back to peer address");
+    assert!(
+        origin.parse::<std::net::IpAddr>().is_ok(),
+        "origin should be a valid IP: {origin}"
+    );
+}
+
+#[tokio::test]
+async fn test_ip_respects_forwarded_header() {
+    let base = spawn_app().await;
+    let client = reqwest::Client::new();
+    let resp = client
+        .get(format!("{base}/ip"))
+        .header("x-forwarded-for", "203.0.113.42, 10.0.0.1")
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), 200);
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(body["origin"], "203.0.113.42");
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- `ip_handler` no longer returns `"unknown"` for direct-connect requests. Priority remains `X-Forwarded-For → X-Real-IP`, now with a peer-address fallback from the TCP connection before hitting the final `"unknown"` sentinel.
- Both HTTP and HTTPS listeners in `src/server/http.rs` bind via `into_make_service_with_connect_info::<SocketAddr>()` so `ConnectInfo` is available to the handler.
- Integration tests updated: `test_ip` now asserts a parseable IP (rejects `"unknown"`), and a new `test_ip_respects_forwarded_header` pins the `X-Forwarded-For` → leftmost-IP precedence.
- Roadmap tick + Priority Order rotation folded into the same PR.

## Test plan
- [x] `cargo fmt` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo test` — 90 unit + 16 integration + 1 doc test pass
- [x] Existing `test_ip` now fails if the fallback regresses

🤖 Generated with [Claude Code](https://claude.com/claude-code)