### PR TITLE
feat: Add /response-headers endpoint for response-transformer testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - `/base64/:encoded` endpoint — decode URL-safe base64 strings and return JSON with decoded content, UTF-8 validity, and byte length. Accepts URL-safe base64 with or without padding; standard base64 is attempted as a fallback. Input capped at 4096 bytes.
 - `max_body_size_bytes` config field (env: `RUCHO_MAX_BODY_SIZE_BYTES`, default: 2 MiB) — caps request body size globally via `DefaultBodyLimit`. Requests exceeding the limit receive 413 Payload Too Large.
+- `/response-headers?key=value` endpoint — echoes each query parameter as a response header and in the JSON body. Duplicate keys emit repeated headers and collapse to a JSON array. User-supplied headers replace defaults (including `content-type`). Invalid header names or values return 400. Designed for exercising gateway plugins that mutate upstream response headers (Kong's `response-transformer`, `cors`, `proxy-cache`).
 
 ### Fixed
 - `/anything` handler no longer reads the full request body with `usize::MAX` limit — closes an OOM vector. `anything_handler` now uses the `Bytes` extractor which honors the configured `max_body_size_bytes`.

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ rucho version  # Display version
 | GET     | `/cookies/set`    | Set cookies via query params and redirect            |
 | GET     | `/cookies/delete` | Delete cookies via query params and redirect         |
 | GET     | `/base64/:encoded`| Decode URL-safe base64 (max 4096 bytes)              |
+| GET     | `/response-headers`| Echo query params as response headers + JSON body   |
 | GET     | `/uuid`           | Random UUID v4                                       |
 | GET     | `/ip`             | Client IP address                                    |
 | GET     | `/user-agent`     | User-Agent header echo                               |
@@ -171,6 +172,7 @@ src/
 │   ├── core_routes.rs   # Core echo + utility endpoints
 │   ├── delay.rs         # /delay/:n endpoint
 │   ├── healthz.rs       # /healthz endpoint
+│   ├── response_headers.rs # /response-headers endpoint
 │   ├── metrics.rs       # /metrics endpoint handler
 │   └── redirect.rs      # /redirect/:n endpoint
 ├── server/              # Server setup and orchestration

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -81,7 +81,7 @@
 - [ ] `/image/:format` — return a small test image (png, jpeg, svg, webp)
 
 ### Response Control
-- [ ] `/response-headers?key=value` — return arbitrary response headers via query params
+- [x] `/response-headers?key=value` — return arbitrary response headers via query params (PR #113)
 - [ ] `/cache` + `/cache/:seconds` — return cache headers (`ETag`, `Last-Modified`, `Cache-Control`)
 - [ ] `/gzip`, `/brotli`, `/deflate` — force a specific encoding regardless of `Accept-Encoding`
 
@@ -251,7 +251,7 @@
 
 Ranked by payoff-per-hour from the review:
 
-1. **`/response-headers` + `/bytes` + `/drip`** — highest-ROI roadmap endpoints for exercising gateway plugins (response-transformer, request-size-limiting, timeout policy)
+1. **`/bytes` + `/drip`** — remaining Tier 3 plugin-testing endpoints (request-size-limiting, timeout policy). `/response-headers` shipped in PR #113.
 2. **`cargo audit` + Dependabot in CI** — supply-chain hygiene, trivial to add
 3. **CI matrix adds `windows-latest`** — prevents the WSL-dev drift the memory flags
 4. **Multi-arch Docker image** — small CI change, big UX win for Mac users

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,6 +52,7 @@ use rucho::utils::metrics::Metrics;
         rucho::routes::cookies::set_cookies_handler,
         rucho::routes::cookies::delete_cookies_handler,
         rucho::routes::base64::base64_handler,
+        rucho::routes::response_headers::response_headers_handler,
         rucho::routes::core_routes::uuid_handler,
         rucho::routes::core_routes::ip_handler,
         rucho::routes::core_routes::user_agent_handler,
@@ -154,6 +155,7 @@ fn build_app(
         .merge(rucho::routes::redirect::router())
         .merge(rucho::routes::cookies::router())
         .merge(rucho::routes::base64::router())
+        .merge(rucho::routes::response_headers::router())
         .layer(DefaultBodyLimit::max(max_body_size_bytes));
 
     // Add metrics endpoint and middleware if enabled

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -7,6 +7,9 @@
 //! - [`core_routes`] - Main API endpoints (GET, POST, PUT, PATCH, DELETE, etc.)
 //! - [`delay`] - Delay endpoint for testing timeouts
 //! - [`healthz`] - Health check endpoint
+//! - [`metrics`] - Metrics endpoint (JSON)
+//! - [`redirect`] - Chained redirect endpoint
+//! - [`response_headers`] - Echo query params as response headers
 
 /// Module for the base64 decoding endpoint (`/base64/:encoded`).
 pub mod base64;
@@ -22,3 +25,5 @@ pub mod healthz;
 pub mod metrics;
 /// Module for the redirect endpoint (`/redirect/:n`).
 pub mod redirect;
+/// Module for the response-headers endpoint (`/response-headers`).
+pub mod response_headers;

--- a/src/routes/response_headers.rs
+++ b/src/routes/response_headers.rs
@@ -1,0 +1,238 @@
+//! Response-headers endpoint.
+//!
+//! Mirrors each query parameter into the response headers (and JSON body) so
+//! that gateway plugins operating on upstream response headers — Kong's
+//! `response-transformer`, `cors`, `proxy-cache`, etc. — can be exercised
+//! against a deterministic upstream.
+
+use axum::{
+    http::{HeaderName, HeaderValue, StatusCode},
+    response::Response,
+    routing::get,
+    Extension, Router,
+};
+use serde_json::{Map, Value};
+use std::collections::HashSet;
+
+use crate::utils::{
+    error_response::format_error_response, json_response::format_json_response_with_timing,
+    timing::RequestTiming,
+};
+
+/// Echoes each query parameter as a response header and in the JSON body.
+///
+/// `GET /response-headers?x-rate-limit=100&cache-control=no-store` returns:
+/// - Response headers `x-rate-limit: 100` and `cache-control: no-store`
+/// - JSON body `{"x-rate-limit": "100", "cache-control": "no-store"}`
+///
+/// Duplicate keys emit multiple response headers (HTTP's repeat-header model)
+/// and collapse to a JSON array in the body. Invalid header names or values
+/// return 400.
+///
+/// User-supplied headers replace any defaults — setting `content-type`
+/// overrides the default `application/json` (body remains JSON regardless;
+/// the mismatch is intentional for plugin-testing scenarios).
+#[utoipa::path(
+    get,
+    path = "/response-headers",
+    responses(
+        (status = 200, description = "Echoes query params as response headers and a JSON body"),
+        (status = 400, description = "Invalid header name or value")
+    )
+)]
+pub async fn response_headers_handler(
+    axum::extract::Query(params): axum::extract::Query<Vec<(String, String)>>,
+    timing: Option<Extension<RequestTiming>>,
+) -> Response {
+    // Validate and parse all headers first. On any error, short-circuit with 400
+    // before mutating the response.
+    let mut parsed: Vec<(HeaderName, HeaderValue)> = Vec::with_capacity(params.len());
+    for (key, value) in &params {
+        let header_name = match HeaderName::from_bytes(key.as_bytes()) {
+            Ok(n) => n,
+            Err(_) => {
+                return format_error_response(
+                    StatusCode::BAD_REQUEST,
+                    &format!("Invalid header name: {key}"),
+                );
+            }
+        };
+        let header_value = match HeaderValue::from_str(value) {
+            Ok(v) => v,
+            Err(_) => {
+                return format_error_response(
+                    StatusCode::BAD_REQUEST,
+                    &format!("Invalid header value for {key}"),
+                );
+            }
+        };
+        parsed.push((header_name, header_value));
+    }
+
+    // Build JSON body; duplicate keys collapse to arrays.
+    let mut body = Map::new();
+    for (key, value) in params {
+        match body.remove(&key) {
+            Some(Value::Array(mut arr)) => {
+                arr.push(Value::String(value));
+                body.insert(key, Value::Array(arr));
+            }
+            Some(existing) => {
+                body.insert(key, Value::Array(vec![existing, Value::String(value)]));
+            }
+            None => {
+                body.insert(key, Value::String(value));
+            }
+        }
+    }
+
+    let duration_ms = timing.map(|t| t.elapsed_ms());
+    let mut response = format_json_response_with_timing(Value::Object(body), duration_ms);
+
+    // User headers replace any defaults (e.g. the default `content-type:
+    // application/json`). Clear defaults for every user-supplied name, then
+    // append — so duplicate query keys map to duplicate response headers.
+    let response_headers = response.headers_mut();
+    let user_names: HashSet<HeaderName> = parsed.iter().map(|(n, _)| n.clone()).collect();
+    for name in &user_names {
+        response_headers.remove(name);
+    }
+    for (name, value) in parsed {
+        response_headers.append(name, value);
+    }
+
+    response
+}
+
+/// Creates and returns the Axum router for the response-headers endpoint.
+pub fn router() -> Router {
+    Router::new().route("/response-headers", get(response_headers_handler))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::body::Body;
+    use axum::http::Request;
+    use serde_json::json;
+    use tower::ServiceExt;
+
+    #[tokio::test]
+    async fn test_single_header() {
+        let app = router();
+        let response = app
+            .oneshot(
+                Request::get("/response-headers?x-custom=hello")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(response.headers().get("x-custom").unwrap(), "hello");
+
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["x-custom"], "hello");
+    }
+
+    #[tokio::test]
+    async fn test_multiple_headers() {
+        let app = router();
+        let response = app
+            .oneshot(
+                Request::get("/response-headers?x-rate-limit=100&cache-control=no-store")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.headers().get("x-rate-limit").unwrap(), "100");
+        assert_eq!(response.headers().get("cache-control").unwrap(), "no-store");
+    }
+
+    #[tokio::test]
+    async fn test_duplicate_keys_become_array() {
+        let app = router();
+        let response = app
+            .oneshot(
+                Request::get("/response-headers?x=1&x=2")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        let x_values: Vec<_> = response.headers().get_all("x").iter().collect();
+        assert_eq!(x_values.len(), 2);
+
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["x"], json!(["1", "2"]));
+    }
+
+    #[tokio::test]
+    async fn test_invalid_header_name_returns_400() {
+        let app = router();
+        // Newline in header name is invalid per RFC 7230.
+        let response = app
+            .oneshot(
+                Request::get("/response-headers?bad%0Aname=value")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn test_content_type_override() {
+        let app = router();
+        let response = app
+            .oneshot(
+                Request::get("/response-headers?content-type=text/plain")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        // User-supplied content-type replaces the default application/json;
+        // only one content-type header remains.
+        let ct_values: Vec<_> = response.headers().get_all("content-type").iter().collect();
+        assert_eq!(ct_values.len(), 1);
+        assert_eq!(
+            response.headers().get("content-type").unwrap(),
+            "text/plain"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_empty_query_returns_empty_body() {
+        let app = router();
+        let response = app
+            .oneshot(
+                Request::get("/response-headers")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json, json!({}));
+    }
+}

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -5,7 +5,7 @@
 //! actual TCP connections.
 
 use axum::{extract::DefaultBodyLimit, middleware, Router};
-use rucho::routes::{base64, cookies, core_routes, delay, healthz, redirect};
+use rucho::routes::{base64, cookies, core_routes, delay, healthz, redirect, response_headers};
 use rucho::server::timing_layer::timing_middleware;
 use rucho::utils::constants::DEFAULT_MAX_BODY_SIZE_BYTES;
 
@@ -29,6 +29,7 @@ async fn spawn_app_with_body_limit(max_body_size: usize) -> String {
         .merge(redirect::router())
         .merge(cookies::router())
         .merge(base64::router())
+        .merge(response_headers::router())
         .layer(DefaultBodyLimit::max(max_body_size))
         .layer(middleware::from_fn(timing_middleware));
 
@@ -271,6 +272,35 @@ async fn test_anything_wildcard() {
     let body: serde_json::Value = resp.json().await.unwrap();
     assert_eq!(body["method"], "POST");
     assert_eq!(body["path"], "/anything/foo/bar");
+}
+
+#[tokio::test]
+async fn test_response_headers_mirrors_query_params() {
+    let base = spawn_app().await;
+    let resp = reqwest::get(format!(
+        "{base}/response-headers?x-rate-limit=100&cache-control=no-store"
+    ))
+    .await
+    .unwrap();
+
+    assert_eq!(resp.status(), 200);
+    assert_eq!(resp.headers().get("x-rate-limit").unwrap(), "100");
+    assert_eq!(resp.headers().get("cache-control").unwrap(), "no-store");
+
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(body["x-rate-limit"], "100");
+    assert_eq!(body["cache-control"], "no-store");
+}
+
+#[tokio::test]
+async fn test_response_headers_invalid_returns_400() {
+    let base = spawn_app().await;
+    // %0A is a newline — invalid inside a header name.
+    let resp = reqwest::get(format!("{base}/response-headers?bad%0Aname=value"))
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), 400);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- New \`GET /response-headers?key=value\` endpoint echoes each query param as a response header and in the JSON body, providing a deterministic upstream for testing Kong plugins that mutate upstream response headers (\`response-transformer\`, \`cors\`, \`proxy-cache\`, \`correlation-id\`, etc.).
- Duplicate query keys → repeated response headers (HTTP's repeat-header model) and collapse to a JSON array in the body.
- User-supplied headers replace defaults, including the default \`content-type: application/json\`. Body stays JSON even if content-type is overridden — the mismatch is intentional for plugin testing.
- Invalid header names or values return 400.
- Roadmap tick + Priority Order rotation folded into this PR (new #1 is \`/bytes\` + \`/drip\`).

## Test plan
- [x] \`cargo fmt\` — clean
- [x] \`cargo clippy -- -D warnings\` — clean
- [x] \`cargo test\` — 96 unit + 18 integration + 1 doc test pass
- [x] New unit tests cover single/multiple headers, duplicate keys, invalid header names, content-type override, empty query
- [x] New integration tests cover end-to-end mirroring and 400 path

🤖 Generated with [Claude Code](https://claude.com/claude-code)