### PR TITLE
feat: Add /bytes/:n endpoint for binary upstream testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `/base64/:encoded` endpoint — decode URL-safe base64 strings and return JSON with decoded content, UTF-8 validity, and byte length. Accepts URL-safe base64 with or without padding; standard base64 is attempted as a fallback. Input capped at 4096 bytes.
 - `max_body_size_bytes` config field (env: `RUCHO_MAX_BODY_SIZE_BYTES`, default: 2 MiB) — caps request body size globally via `DefaultBodyLimit`. Requests exceeding the limit receive 413 Payload Too Large.
 - `/response-headers?key=value` endpoint — echoes each query parameter as a response header and in the JSON body. Duplicate keys emit repeated headers and collapse to a JSON array. User-supplied headers replace defaults (including `content-type`). Invalid header names or values return 400. Designed for exercising gateway plugins that mutate upstream response headers (Kong's `response-transformer`, `cors`, `proxy-cache`).
+- `/bytes/:n` endpoint — returns `n` random bytes as `application/octet-stream`. Capped at 10 MiB; larger values return 400. Metrics path normalized to `/bytes/:n` to prevent cardinality explosion. Targets gateway response-buffering, binary-integrity, and compression-plugin testing.
 
 ### Fixed
 - `/anything` handler no longer reads the full request body with `usize::MAX` limit — closes an OOM vector. `anything_handler` now uses the `Bytes` extractor which honors the configured `max_body_size_bytes`.

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ rucho version  # Display version
 | GET     | `/cookies/set`    | Set cookies via query params and redirect            |
 | GET     | `/cookies/delete` | Delete cookies via query params and redirect         |
 | GET     | `/base64/:encoded`| Decode URL-safe base64 (max 4096 bytes)              |
+| GET     | `/bytes/:n`       | Return n random bytes (max 10 MiB)                   |
 | GET     | `/response-headers`| Echo query params as response headers + JSON body   |
 | GET     | `/uuid`           | Random UUID v4                                       |
 | GET     | `/ip`             | Client IP address                                    |
@@ -168,6 +169,7 @@ src/
 ├── routes/              # HTTP route handlers
 │   ├── mod.rs
 │   ├── base64.rs        # /base64/:encoded endpoint
+│   ├── bytes.rs         # /bytes/:n endpoint
 │   ├── cookies.rs       # /cookies endpoints
 │   ├── core_routes.rs   # Core echo + utility endpoints
 │   ├── delay.rs         # /delay/:n endpoint

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -76,7 +76,7 @@
 
 ### Data Formats & Content Types
 - [x] `/base64/:encoded` — decode base64 in the URL and return the result
-- [ ] `/bytes/:n` — return `n` random bytes (binary download testing)
+- [x] `/bytes/:n` — return `n` random bytes (binary download testing) (PR #114)
 - [ ] `/xml`, `/html` — return non-JSON content types
 - [ ] `/image/:format` — return a small test image (png, jpeg, svg, webp)
 
@@ -251,7 +251,7 @@
 
 Ranked by payoff-per-hour from the review:
 
-1. **`/bytes` + `/drip`** — remaining Tier 3 plugin-testing endpoints (request-size-limiting, timeout policy). `/response-headers` shipped in PR #113.
+1. **`/drip`** — final Tier 3 plugin-testing endpoint for slow-streaming upstream behavior (tests `read_timeout` / `send_timeout` policies). `/response-headers` shipped in PR #113; `/bytes` shipped in PR #114.
 2. **`cargo audit` + Dependabot in CI** — supply-chain hygiene, trivial to add
 3. **CI matrix adds `windows-latest`** — prevents the WSL-dev drift the memory flags
 4. **Multi-arch Docker image** — small CI change, big UX win for Mac users

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,6 +52,7 @@ use rucho::utils::metrics::Metrics;
         rucho::routes::cookies::set_cookies_handler,
         rucho::routes::cookies::delete_cookies_handler,
         rucho::routes::base64::base64_handler,
+        rucho::routes::bytes::bytes_handler,
         rucho::routes::response_headers::response_headers_handler,
         rucho::routes::core_routes::uuid_handler,
         rucho::routes::core_routes::ip_handler,
@@ -155,6 +156,7 @@ fn build_app(
         .merge(rucho::routes::redirect::router())
         .merge(rucho::routes::cookies::router())
         .merge(rucho::routes::base64::router())
+        .merge(rucho::routes::bytes::router())
         .merge(rucho::routes::response_headers::router())
         .layer(DefaultBodyLimit::max(max_body_size_bytes));
 

--- a/src/routes/bytes.rs
+++ b/src/routes/bytes.rs
@@ -1,0 +1,144 @@
+//! Bytes endpoint — returns N random bytes as `application/octet-stream`.
+//!
+//! Provides a controllable upstream emitting arbitrary-sized binary bodies,
+//! useful for exercising gateway proxy behavior: response buffering, chunked
+//! transfer, binary integrity, and compression-plugin behavior on
+//! incompressible data.
+
+use axum::{
+    http::{header, StatusCode},
+    response::{IntoResponse, Response},
+    routing::get,
+    Router,
+};
+use rand::RngCore;
+
+use crate::utils::{constants::MAX_BYTES_RESPONSE_SIZE, error_response::format_error_response};
+
+/// Returns `n` random bytes as the response body.
+///
+/// Response headers: `Content-Type: application/octet-stream`, `Content-Length: n`.
+/// `n` is capped at `MAX_BYTES_RESPONSE_SIZE` (10 MiB); larger values return 400.
+/// `n = 0` returns an empty 200 OK.
+///
+/// The body is filled via `rand::thread_rng().fill_bytes(&mut buf[..])` for
+/// maximum-entropy payloads (useful for verifying binary integrity through a
+/// proxy, since any tampering is observable).
+#[utoipa::path(
+    get,
+    path = "/bytes/{n}",
+    params(
+        ("n" = usize, Path, description = "Number of random bytes to return (max 10485760)")
+    ),
+    responses(
+        (status = 200, description = "Returns n random bytes as application/octet-stream", body = Vec<u8>),
+        (status = 400, description = "n exceeds MAX_BYTES_RESPONSE_SIZE")
+    )
+)]
+pub async fn bytes_handler(axum::extract::Path(n): axum::extract::Path<usize>) -> Response {
+    if n > MAX_BYTES_RESPONSE_SIZE {
+        return format_error_response(
+            StatusCode::BAD_REQUEST,
+            &format!("Requested {n} bytes exceeds maximum of {MAX_BYTES_RESPONSE_SIZE} bytes"),
+        );
+    }
+
+    let mut buf = vec![0u8; n];
+    rand::thread_rng().fill_bytes(&mut buf);
+
+    ([(header::CONTENT_TYPE, "application/octet-stream")], buf).into_response()
+}
+
+/// Creates and returns the Axum router for the bytes endpoint.
+pub fn router() -> Router {
+    Router::new().route("/bytes/:n", get(bytes_handler))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::body::Body;
+    use axum::http::Request;
+    use tower::ServiceExt;
+
+    #[tokio::test]
+    async fn test_returns_n_bytes() {
+        let app = router();
+        let response = app
+            .oneshot(Request::get("/bytes/1024").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(
+            response.headers().get(header::CONTENT_TYPE).unwrap(),
+            "application/octet-stream"
+        );
+
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        assert_eq!(body.len(), 1024);
+    }
+
+    #[tokio::test]
+    async fn test_zero_bytes() {
+        let app = router();
+        let response = app
+            .oneshot(Request::get("/bytes/0").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        assert_eq!(body.len(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_exceeds_max_returns_400() {
+        let app = router();
+        let response = app
+            .oneshot(
+                Request::get(format!("/bytes/{}", MAX_BYTES_RESPONSE_SIZE + 1))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn test_at_max_succeeds() {
+        let app = router();
+        let response = app
+            .oneshot(
+                Request::get(format!("/bytes/{MAX_BYTES_RESPONSE_SIZE}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        assert_eq!(body.len(), MAX_BYTES_RESPONSE_SIZE);
+    }
+
+    #[tokio::test]
+    async fn test_non_numeric_path_returns_400() {
+        let app = router();
+        let response = app
+            .oneshot(Request::get("/bytes/abc").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+
+        // Axum's Path<usize> extraction failure returns 400.
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    }
+}

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -3,6 +3,7 @@
 //! This module contains all the HTTP route handlers organized into submodules:
 //!
 //! - [`base64`] - Base64 decoding endpoint
+//! - [`bytes`] - Random bytes endpoint
 //! - [`cookies`] - Cookie inspection and manipulation endpoints
 //! - [`core_routes`] - Main API endpoints (GET, POST, PUT, PATCH, DELETE, etc.)
 //! - [`delay`] - Delay endpoint for testing timeouts
@@ -13,6 +14,8 @@
 
 /// Module for the base64 decoding endpoint (`/base64/:encoded`).
 pub mod base64;
+/// Module for the random-bytes endpoint (`/bytes/:n`).
+pub mod bytes;
 /// Module for the cookie inspection and manipulation endpoints (`/cookies`).
 pub mod cookies;
 /// Module for core API routes, including various HTTP method handlers and utility endpoints.

--- a/src/server/metrics_layer.rs
+++ b/src/server/metrics_layer.rs
@@ -47,6 +47,7 @@ fn normalize_path(path: &str) -> Cow<'static, str> {
             Some(&"status") if segments.len() >= 3 => Cow::Borrowed("/status/:code"),
             Some(&"delay") if segments.len() >= 3 => Cow::Borrowed("/delay/:n"),
             Some(&"redirect") if segments.len() >= 3 => Cow::Borrowed("/redirect/:n"),
+            Some(&"bytes") if segments.len() >= 3 => Cow::Borrowed("/bytes/:n"),
             Some(&"cookies") if segments.len() >= 3 => {
                 let action = segments.get(2).unwrap_or(&"");
                 Cow::Owned(format!("/cookies/{action}"))
@@ -81,6 +82,13 @@ mod tests {
         assert_eq!(normalize_path("/redirect/3"), "/redirect/:n");
         assert_eq!(normalize_path("/redirect/1"), "/redirect/:n");
         assert_eq!(normalize_path("/redirect/20"), "/redirect/:n");
+    }
+
+    #[test]
+    fn test_normalize_bytes_path() {
+        assert_eq!(normalize_path("/bytes/1024"), "/bytes/:n");
+        assert_eq!(normalize_path("/bytes/0"), "/bytes/:n");
+        assert_eq!(normalize_path("/bytes/10485760"), "/bytes/:n");
     }
 
     #[test]

--- a/src/utils/constants.rs
+++ b/src/utils/constants.rs
@@ -35,6 +35,11 @@ pub const MAX_BASE64_INPUT_BYTES: usize = 4096;
 /// handlers, including `anything_handler`. Protects against OOM from unbounded bodies.
 pub const DEFAULT_MAX_BODY_SIZE_BYTES: usize = 2 * 1024 * 1024;
 
+/// Maximum number of random bytes the `/bytes/:n` endpoint will emit (10 MiB).
+/// Requests for more return 400. Prevents a single request from allocating
+/// unbounded memory to generate the response body.
+pub const MAX_BYTES_RESPONSE_SIZE: usize = 10 * 1024 * 1024;
+
 /// Maximum buffer size in bytes for TCP/UDP connections.
 /// This prevents memory exhaustion from malicious large payloads.
 pub const MAX_BUFFER_SIZE: usize = 65536;

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -5,7 +5,9 @@
 //! actual TCP connections.
 
 use axum::{extract::DefaultBodyLimit, middleware, Router};
-use rucho::routes::{base64, cookies, core_routes, delay, healthz, redirect, response_headers};
+use rucho::routes::{
+    base64, bytes, cookies, core_routes, delay, healthz, redirect, response_headers,
+};
 use rucho::server::timing_layer::timing_middleware;
 use rucho::utils::constants::DEFAULT_MAX_BODY_SIZE_BYTES;
 
@@ -29,6 +31,7 @@ async fn spawn_app_with_body_limit(max_body_size: usize) -> String {
         .merge(redirect::router())
         .merge(cookies::router())
         .merge(base64::router())
+        .merge(bytes::router())
         .merge(response_headers::router())
         .layer(DefaultBodyLimit::max(max_body_size))
         .layer(middleware::from_fn(timing_middleware));
@@ -272,6 +275,31 @@ async fn test_anything_wildcard() {
     let body: serde_json::Value = resp.json().await.unwrap();
     assert_eq!(body["method"], "POST");
     assert_eq!(body["path"], "/anything/foo/bar");
+}
+
+#[tokio::test]
+async fn test_bytes_returns_correct_size_and_type() {
+    let base = spawn_app().await;
+    let resp = reqwest::get(format!("{base}/bytes/512")).await.unwrap();
+
+    assert_eq!(resp.status(), 200);
+    assert_eq!(
+        resp.headers().get("content-type").unwrap(),
+        "application/octet-stream"
+    );
+    let body = resp.bytes().await.unwrap();
+    assert_eq!(body.len(), 512);
+}
+
+#[tokio::test]
+async fn test_bytes_exceeds_max_returns_400() {
+    let base = spawn_app().await;
+    // 10 MiB + 1 is one over the cap.
+    let resp = reqwest::get(format!("{base}/bytes/{}", 10 * 1024 * 1024 + 1))
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), 400);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- New \`GET /bytes/:n\` endpoint returns \`n\` random bytes as \`application/octet-stream\`. Capped at \`MAX_BYTES_RESPONSE_SIZE\` (10 MiB); larger values return 400.
- Provides a controllable upstream for testing gateway response-buffering, chunked transfer, binary integrity, and compression-plugin behavior on incompressible (max-entropy) data.
- Normalizes \`/bytes/:n\` in the metrics layer's \`normalize_path()\` so the metrics store doesn't accumulate unbounded path labels — mirrors existing \`/delay\`, \`/redirect\` treatment.
- Roadmap tick + Priority Order rotation folded into this PR (new #1 is just \`/drip\`).

## Design choices
- **Raw binary body** (no JSON wrapper) — intentional deviation from the JSON-everywhere convention since the whole point is arbitrary-byte integrity.
- **Bulk fill** via \`rand::thread_rng().fill_bytes()\` — avoids per-byte overhead; \`rand\` crate already a dependency.
- **10 MiB cap** — separate from \`max_body_size_bytes\` (that's request-side); 10 MiB is large enough for realistic testing while bounding single-request memory.
- **No seed param** — deliberate omission; can be added later if a reproducibility use case emerges.

## Test plan
- [x] \`cargo fmt\` — clean
- [x] \`cargo clippy -- -D warnings\` — clean
- [x] \`cargo test\` — 102 unit + 20 integration + 1 doc test pass
- [x] Unit tests cover 1024 bytes, 0 bytes, over-max (400), at-max (success), non-numeric path (400), and metrics path normalization
- [x] Integration tests cover end-to-end size/content-type and the 400 over-limit path

🤖 Generated with [Claude Code](https://claude.com/claude-code)