### PR TITLE
docs: Sync docs with Tier 3 plugin-testing trio

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -148,12 +148,15 @@ src/
 ├── routes/              # HTTP route handlers
 │   ├── mod.rs
 │   ├── base64.rs        # /base64/:encoded endpoint
+│   ├── bytes.rs         # /bytes/:n endpoint
 │   ├── cookies.rs       # /cookies endpoints
 │   ├── core_routes.rs   # Core echo + utility endpoints
 │   ├── delay.rs         # /delay/:n endpoint
+│   ├── drip.rs          # /drip slow-streaming endpoint
 │   ├── healthz.rs       # /healthz endpoint
 │   ├── metrics.rs       # /metrics endpoint handler
-│   └── redirect.rs      # /redirect/:n endpoint
+│   ├── redirect.rs      # /redirect/:n endpoint
+│   └── response_headers.rs # /response-headers endpoint
 ├── server/              # Server setup and orchestration
 │   ├── mod.rs
 │   ├── chaos_layer.rs   # Chaos engineering middleware

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -221,6 +221,33 @@ Returns all request headers as a JSON object.
 }
 ```
 
+### GET /response-headers
+
+Echoes each query parameter as a response header **and** in the JSON body. Useful for exercising gateway plugins that inspect or rewrite upstream response headers (Kong's `response-transformer`, `cors`, `proxy-cache`).
+
+**Query parameters:** Any number of `key=value` pairs. Duplicate keys emit repeated `Set-Header`-style entries on the response and collapse to a JSON array in the body. User-supplied headers replace the default response headers (including `content-type`; the body is still JSON — intentional mismatch for plugin testing).
+
+**Response:** `200 OK` — JSON body mirroring the headers.
+
+```bash
+curl -i 'http://localhost:8080/response-headers?x-rate-limit=100&cache-control=no-store'
+```
+
+```http
+HTTP/1.1 200 OK
+x-rate-limit: 100
+cache-control: no-store
+
+{
+  "x-rate-limit": "100",
+  "cache-control": "no-store"
+}
+```
+
+**Errors:**
+
+- `400 Bad Request` — invalid header name (must be valid HTTP token) or invalid header value (must be visible ASCII)
+
 ---
 
 ## Status Codes
@@ -434,6 +461,53 @@ Decodes a URL-safe base64-encoded string from the URL path and returns metadata 
 
 ```bash
 curl http://localhost:8080/base64/SGVsbG8sIFJ1Y2hvIQ==
+```
+
+### GET /bytes/:n
+
+Returns `n` random bytes as `application/octet-stream`. The body is filled via `rand::thread_rng().fill_bytes()` for maximum entropy, which makes any tampering by an intermediate proxy observable.
+
+**Path parameters:**
+
+| Name | Description |
+|------|-------------|
+| `n` | Number of random bytes to return. Capped at 10 MiB (10 485 760). |
+
+**Response:** `200 OK` — raw bytes with `Content-Type: application/octet-stream` and `Content-Length: n`. `n = 0` returns an empty 200.
+
+**Errors:**
+
+- `400 Bad Request` — `n` exceeds the 10 MiB cap
+
+```bash
+curl -o random.bin http://localhost:8080/bytes/1024
+```
+
+### GET /drip
+
+Streams `numbytes` bytes of `*` evenly over `duration` seconds via `Transfer-Encoding: chunked`. Distinct from `/delay/:n`, which exercises *first-byte* (idle) timeouts: `/drip` exercises the *streaming* / inter-byte timeouts that fire when bytes are arriving but slowly (Kong's `read_timeout` / `send_timeout`, response buffering vs streaming behavior).
+
+**Query parameters (all optional):**
+
+| Name | Default | Description |
+|------|---------|-------------|
+| `numbytes` | `10` | Total bytes to emit. Capped at 10 000. |
+| `duration` | `2` | Total stream duration in seconds. Capped at 300. |
+| `code` | `200` | HTTP status code to return. Must be a valid HTTP status (100–999). |
+| `delay` | `0` | Initial delay in seconds before the first byte. Capped at 300. |
+
+**Response:** Status `code` (default `200`), `Content-Type: application/octet-stream`, body of `numbytes` `*` characters spread evenly across `duration` seconds. Chunk pacing is clamped so emissions are at least ~1 ms apart (tokio's timer precision).
+
+**Errors:**
+
+- `400 Bad Request` — any cap exceeded, or `code` is not a valid HTTP status
+
+```bash
+# 100 bytes spread over 5 seconds
+curl http://localhost:8080/drip?numbytes=100&duration=5
+
+# Test how a proxy handles a slow 504 upstream
+curl -i 'http://localhost:8080/drip?numbytes=20&duration=3&code=504'
 ```
 
 ---

--- a/docs/INTERNALS.md
+++ b/docs/INTERNALS.md
@@ -83,12 +83,15 @@ rucho (crate root)
   +-- routes/                # HTTP route handlers
   |   +-- mod.rs             # Re-exports submodules
   |   +-- base64.rs          # /base64/:encoded handler + router()
+  |   +-- bytes.rs           # /bytes/:n handler + router()
   |   +-- cookies.rs         # /cookies, /cookies/set, /cookies/delete handlers + router()
   |   +-- core_routes.rs     # 16 route handlers + router()
   |   +-- delay.rs           # /delay/:n handler + router()
+  |   +-- drip.rs            # /drip handler + router() (slow-streaming)
   |   +-- healthz.rs         # /healthz handler + router()
   |   +-- metrics.rs         # /metrics handler (stateful)
-  |   +-- redirect.rs       # /redirect/:n handler + router()
+  |   +-- redirect.rs        # /redirect/:n handler + router()
+  |   +-- response_headers.rs # /response-headers handler + router()
   |
   +-- server/                # Server setup and orchestration
   |   +-- mod.rs             # run_server() — top-level orchestrator
@@ -623,6 +626,9 @@ The response travels back up through each middleware layer:
 | 23 | `/cookies/set` | GET | `set_cookies_handler` | `cookies.rs` |
 | 24 | `/cookies/delete` | GET | `delete_cookies_handler` | `cookies.rs` |
 | 25 | `/base64/:encoded` | GET | `base64_handler` | `base64.rs` |
+| 26 | `/bytes/:n` | GET | `bytes_handler` | `bytes.rs` |
+| 27 | `/response-headers` | GET | `response_headers_handler` | `response_headers.rs` |
+| 28 | `/drip` | GET | `drip_handler` | `drip.rs` |
 
 ### 5.2 Echo Handlers
 

--- a/docs/USAGE_EXAMPLES.md
+++ b/docs/USAGE_EXAMPLES.md
@@ -22,6 +22,9 @@ All examples assume rucho is running at `http://localhost:8080` (the default).
 - [Delay & Timeout Testing](#delay--timeout-testing)
 - [Cookie Management](#cookie-management)
 - [Base64 Decoding](#base64-decoding)
+- [Custom Response Headers](#custom-response-headers)
+- [Random Bytes](#random-bytes)
+- [Slow Streaming (Drip)](#slow-streaming-drip)
 - [Chaos Engineering](#chaos-engineering)
 - [Health Checks & Monitoring](#health-checks--monitoring)
 
@@ -777,6 +780,152 @@ curl -i http://localhost:8080/base64/a
 
 # Input exceeds 4096-byte cap — returns 400
 curl -i "http://localhost:8080/base64/$(python3 -c 'print("A"*4097)')"
+```
+
+---
+
+## Custom Response Headers
+
+`/response-headers` echoes each query parameter as both a response header and a field in the JSON body. Useful for exercising gateway plugins that mutate or inspect upstream response headers — Kong's `response-transformer`, `cors`, `proxy-cache`, and so on. Duplicate keys emit repeated headers and collapse to a JSON array in the body. User-supplied headers replace defaults (including `content-type`; the body is still JSON — intentional mismatch for plugin testing).
+
+### Basic usage
+
+```bash
+curl -i 'http://localhost:8080/response-headers?x-rate-limit=100&cache-control=no-store'
+```
+
+```http
+HTTP/1.1 200 OK
+x-rate-limit: 100
+cache-control: no-store
+
+{
+  "x-rate-limit": "100",
+  "cache-control": "no-store"
+}
+```
+
+### Scenario: validate a `response-transformer` plugin
+
+Configure your gateway to *strip* `x-internal-token` from upstream responses, then point it at this endpoint:
+
+```bash
+# Without the plugin: header passes through
+curl -i 'http://gateway/response-headers?x-internal-token=secret'
+
+# With the plugin: header should be removed
+```
+
+### Duplicate keys
+
+```bash
+curl -i 'http://localhost:8080/response-headers?set-cookie=a=1&set-cookie=b=2'
+```
+
+Emits `Set-Cookie: a=1` and `Set-Cookie: b=2` as two separate headers; the body collapses to `{"set-cookie": ["a=1", "b=2"]}`.
+
+### Error cases
+
+```bash
+# Invalid header name (newline) — returns 400
+curl -i 'http://localhost:8080/response-headers?bad%0Aname=value'
+```
+
+---
+
+## Random Bytes
+
+`/bytes/:n` returns `n` random bytes as `application/octet-stream`. The body is filled with maximum-entropy random data, so any tampering by an intermediate proxy is observable. Capped at 10 MiB (10 485 760).
+
+### Download a random binary blob
+
+```bash
+curl -o random.bin http://localhost:8080/bytes/4096
+ls -lh random.bin   # 4.0K
+```
+
+### Scenario: verify a proxy doesn't corrupt binary upstreams
+
+Compare the SHA-256 of the response when going direct vs. through your gateway:
+
+```bash
+# Direct
+curl -s http://localhost:8080/bytes/65536 | sha256sum
+
+# Through gateway — should be identical
+curl -s http://gateway/bytes/65536 | sha256sum
+```
+
+### Scenario: exercise compression-plugin behavior on incompressible data
+
+Random bytes don't compress, so a gzip plugin should either skip them or report ~0% reduction:
+
+```bash
+curl -i -H 'Accept-Encoding: gzip' http://localhost:8080/bytes/100000
+```
+
+### Error cases
+
+```bash
+# Exceeds 10 MiB cap — returns 400
+curl -i http://localhost:8080/bytes/10485761
+```
+
+---
+
+## Slow Streaming (Drip)
+
+`/drip` streams `numbytes` bytes of `*` evenly over `duration` seconds via `Transfer-Encoding: chunked`. Distinct from `/delay/:n` — that exercises *first-byte* (idle) timeouts, while `/drip` exercises the *streaming* timeouts that fire when bytes are arriving but slowly (Kong's `read_timeout` / `send_timeout`, response buffering vs streaming).
+
+Query parameters (all optional): `numbytes` (default 10, max 10 000), `duration` (default 2, max 300), `code` (default 200), `delay` (initial wait before first byte, default 0, max 300).
+
+### Basic usage
+
+```bash
+# 100 bytes spread over 5 seconds
+time curl -s http://localhost:8080/drip?numbytes=100&duration=5 | wc -c
+# ~100, ~5s
+```
+
+### Scenario: tune `read_timeout` against a slow upstream
+
+If your gateway's `read_timeout` is 2 s and the upstream emits a byte every 3 s, the connection should drop:
+
+```bash
+curl -i 'http://gateway/drip?numbytes=10&duration=30'
+# Expect a timeout error from the gateway
+```
+
+### Scenario: verify proxy streams instead of buffering
+
+A proxy that buffers the full response will deliver everything at once after `duration`. A streaming proxy will deliver bytes incrementally. Use `curl --no-buffer` and `pv` (pipe viewer) to watch:
+
+```bash
+curl --no-buffer -s 'http://gateway/drip?numbytes=20&duration=10' | pv -c -N drip > /dev/null
+```
+
+### Custom status codes
+
+```bash
+# Test how a proxy handles a slow 504 upstream
+curl -i 'http://localhost:8080/drip?numbytes=20&duration=3&code=504'
+```
+
+### Initial delay before first byte
+
+```bash
+# Wait 2s, then drip 10 bytes over 1s
+curl -i 'http://localhost:8080/drip?numbytes=10&duration=1&delay=2'
+```
+
+### Error cases
+
+```bash
+# numbytes over cap — returns 400
+curl -i 'http://localhost:8080/drip?numbytes=10001'
+
+# Invalid status code — returns 400
+curl -i 'http://localhost:8080/drip?code=1000'
 ```
 
 ---

--- a/src/routes/core_routes.rs
+++ b/src/routes/core_routes.rs
@@ -194,11 +194,34 @@ static API_ENDPOINTS: &[EndpointInfo] = &[
         method: "GET",
         description: "Returns all request headers.",
     },
-    // Add the new entry for /endpoints itself
+    // /endpoints itself
     EndpointInfo {
         path: "/endpoints",
         method: "GET",
         description: "Lists all available API endpoints.",
+    },
+    // Data-format endpoint
+    EndpointInfo {
+        path: "/base64/:encoded",
+        method: "GET",
+        description: "Decodes a URL-safe base64 string from the path and returns metadata as JSON.",
+    },
+    // Tier 3 plugin-testing trio: controllable upstream behaviors for gateway plugin tests
+    EndpointInfo {
+        path: "/bytes/:n",
+        method: "GET",
+        description: "Returns n random bytes as application/octet-stream (max 10 MiB).",
+    },
+    EndpointInfo {
+        path: "/response-headers",
+        method: "GET",
+        description: "Echoes each query parameter as a response header and in the JSON body.",
+    },
+    EndpointInfo {
+        path: "/drip",
+        method: "GET",
+        description:
+            "Streams numbytes bytes of '*' over duration seconds via chunked transfer encoding.",
     },
 ];
 


### PR DESCRIPTION
## Summary
The three Tier 3 endpoints (`/response-headers` #113, `/bytes/:n` #114, `/drip` #115) were merged with their README/CHANGELOG/ROADMAP entries, but the rest of the doc set drifted out of sync. This PR brings everything back into alignment.

## Changes
- **CONTRIBUTING.md** — routes block adds `bytes.rs`, `drip.rs`, `response_headers.rs`
- **docs/API_REFERENCE.md** — new sections for `/response-headers` (under Utility Endpoints), `/bytes/:n` and `/drip` (under Data Formats); each documents query/path params, response shape, errors, and curl examples
- **docs/INTERNALS.md** — endpoint table extended to rows 26–28 (`/bytes/:n`, `/response-headers`, `/drip`); project-tree block in section 2 adds the three new modules
- **docs/USAGE_EXAMPLES.md** — three new sections (Custom Response Headers, Random Bytes, Slow Streaming) with practical scenarios: Kong `response-transformer` validation, binary-integrity checks through a proxy, `read_timeout` / `send_timeout` exercises, streaming-vs-buffering detection. ToC updated.
- **src/routes/core_routes.rs** — bonus runtime-doc fix: `API_ENDPOINTS` static (consumed by `/endpoints` handler) now includes `/base64`, `/bytes`, `/response-headers`, `/drip`. The list had been stale since PR #105 (`/base64`); the three Tier 3 endpoints inherited the same gap.

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test` — 112 unit + 24 integration + 1 doc, all passing
- [x] No new endpoints, only documentation + runtime endpoint list. No behavior change apart from `/endpoints` now correctly listing 4 previously-missing endpoints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)