### PR TITLE
chore(ci): Add Dependabot config for Cargo + GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,41 @@
+# Dependabot configuration for Rucho.
+#
+# Two ecosystems are watched:
+#   - cargo:          tracks Cargo.toml / Cargo.lock against crates.io
+#   - github-actions: tracks pinned action versions in .github/workflows/
+#
+# Updates run weekly (Monday). Minor + patch bumps are batched into one PR
+# per ecosystem to avoid PR sprawl; major bumps still get individual PRs
+# since they may require code changes.
+#
+# Docs: https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: cargo
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      cargo-minor-patch:
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(ci)"
+    groups:
+      actions-minor-patch:
+        update-types:
+          - minor
+          - patch

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -237,9 +237,9 @@
 ## Tier 8: Security & Supply Chain
 
 - [ ] Set `rust-version = "1.70"` in `Cargo.toml` `[package]` and verify — otherwise CONTRIBUTING's "Rust 1.70+" is aspirational
-- [ ] Add `cargo audit` CI job (security advisories against `Cargo.lock`)
+- [ ] Add `cargo audit` CI job (security advisories against `Cargo.lock`) — deferred from PR #117 until Dependabot clears the existing 16 advisories + 5 unmaintained warnings in `Cargo.lock` (else turning audit on red-fails its own enabling PR). Re-enable as a parallel `Audit` job with `rustsec/audit-check@v2` once the lockfile is clean (or carry an `audit.toml` ignore list with rationale per advisory).
 - [ ] Add `cargo deny` CI job (license + advisory policy enforcement)
-- [ ] Add `.github/dependabot.yml` for Cargo + Docker + GitHub Actions — ~15 lines, saves weekly manual bumps
+- [x] Add `.github/dependabot.yml` for Cargo + GitHub Actions — weekly Monday cadence, minor+patch bumps grouped per ecosystem. Docker omitted (no version-pinning in Dockerfile beyond a single `FROM rust:...` we already control). (PR #117)
 - [ ] Configurable CORS — gate the permissive default behind a `cors_allowed_origins` config field (comma-separated list, `*` preserved as opt-in)
 - [ ] HSTS header for TLS listeners (`Strict-Transport-Security: max-age=...`)
 - [ ] Rate limiting on standalone deploys — optional, or document that "a gateway should handle this" in README (since single client can saturate `/delay`)
@@ -251,13 +251,13 @@
 
 Ranked by payoff-per-hour from the review:
 
-1. **`cargo audit` + Dependabot in CI** — supply-chain hygiene, trivial to add
+1. **`cargo audit` CI job** — deferred from PR #117; revisit after Dependabot has had a couple weeks to land dep-bump PRs and shrink the existing advisory list. Either turn audit on clean or ship with a documented `audit.toml` ignore list.
 2. **CI matrix adds `windows-latest`** — prevents the WSL-dev drift the memory flags
 3. **Multi-arch Docker image** — small CI change, big UX win for Mac users
 4. **Metrics lock contention (DashMap / sharded atomics)** — only matters past ~10k rps; do it when benchmarks say so
 5. **Handler boilerplate DRY** — optional; the current "deferred" decision is defensible
 
-(Tier 3 plugin-testing trio complete: `/response-headers` PR #113, `/bytes` PR #114, `/drip` PR #115.)
+(Tier 3 plugin-testing trio complete: `/response-headers` PR #113, `/bytes` PR #114, `/drip` PR #115. Dependabot landed in PR #117; audit job follows once advisories shrink.)
 
 ---
 


### PR DESCRIPTION
## Summary
Adds `.github/dependabot.yml` to start auto-bumping dependencies. The companion `cargo audit` CI job is **deferred** — local audit shows 16 existing advisories + 5 unmaintained warnings in `Cargo.lock`, so turning audit on right now would red-fail its own enabling PR.

## Dependabot config
- **Ecosystems:** `cargo` (`Cargo.toml` / `Cargo.lock`) and `github-actions` (pinned action versions in workflow files). Docker omitted for now — only pin is the `rust:*` base image we already track manually, and a Dependabot bump would need a release-train coordination we don't have.
- **Schedule:** weekly on Mondays
- **Grouping:** minor + patch bumps batched into one PR per ecosystem (avoids PR sprawl); majors still get individual PRs
- **PR limits:** 5 per ecosystem
- **Commit prefixes:** `chore(deps)` for cargo, `chore(ci)` for actions — keeps bot PRs grouped in the log

## Why audit is deferred
A `cargo audit` run on the current lockfile surfaces:

| Crate | Advisory | Severity | Path |
|---|---|---|---|
| `aws-lc-sys 0.29.0` | RUSTSEC-2026-0045–0048 | medium/high | transitive via rustls |
| `bytes 1.10.1` | RUSTSEC-2026-0007 (integer overflow) | — | transitive via tokio/axum |
| `rustls-webpki 0.102.8 / 0.103.3` | RUSTSEC-2026-0049, 0098, 0099, 0104 | — | transitive via rustls |
| `time 0.3.41` | RUSTSEC-2026-0009 (DoS) | medium | transitive via reqwest |
| `tracing-subscriber 0.3.19` | RUSTSEC-2025-0055 (ANSI log poisoning) | — | **direct dep** |
| `rand 0.8.5` / `0.9.1` | RUSTSEC-2026-0097 (unsound w/ custom logger) | — | direct + transitive |
| `proc-macro-error`, `rustls-pemfile` | unmaintained | warning | transitive (utoipa-gen, axum-server) |

Plan: let Dependabot land bump PRs for one to two weeks, then turn on `cargo audit` against the cleaned lockfile (or with a small documented `audit.toml` ignore list for whatever's transitive-and-stuck).

## ROADMAP changes
- Tier 8: Dependabot ticked; `cargo audit` stays unchecked with deferral rationale inline
- Suggested Priority Order rotated so the audit job is the new #1 to revisit

## Test plan
- [x] No source code changed; Rust workflow unaffected
- [x] YAML structure follows [Dependabot v2 schema](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file)
- [ ] After merge: confirm Dependabot picks up the config (first run within ~24h on the default branch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)