### PR TITLE
docs: Exhaustive sync — stale numbers, missing handler descriptions, README features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - `/anything` handler no longer reads the full request body with `usize::MAX` limit — closes an OOM vector. `anything_handler` now uses the `Bytes` extractor which honors the configured `max_body_size_bytes`.
 - `/ip` no longer returns `"unknown"` when a request arrives without `X-Forwarded-For` or `X-Real-IP` headers. The server now binds with `into_make_service_with_connect_info::<SocketAddr>()`, letting `ip_handler` fall back to the peer address from the TCP connection.
+- `/endpoints` runtime list now includes `/base64`, `/bytes/:n`, `/response-headers`, and `/drip`. These had been missing from the `API_ENDPOINTS` static since each endpoint was added, so the runtime discoverability layer lagged the actual router.
 
 ## [1.4.6] - 2026-02-17
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,12 @@ Designed for testing, debugging, and simulating various HTTP behaviors.
 - Configurable response delay (`/delay/:n`, max 300s)
 - Chained HTTP redirects (`/redirect/:n`, max 20 hops)
 - Cookie inspection, setting, and deletion (`/cookies`, `/cookies/set`, `/cookies/delete`)
+- Base64 decoding with UTF-8 detection (`/base64/:encoded`, max 4 KiB)
+- Gateway plugin-testing trio:
+  - `/response-headers?key=value` — echo query params as response headers
+  - `/bytes/:n` — random bytes as `application/octet-stream` (max 10 MiB)
+  - `/drip?duration=N&numbytes=M` — slow byte stream for inter-byte timeout testing
+- Configurable request body size cap (`max_body_size_bytes`, default 2 MiB)
 - TCP and UDP echo listeners for protocol testing
 - HTTPS support via Rustls with HTTP/2
 - Response compression (gzip, brotli) - optional, client-negotiated

--- a/docs/INTERNALS.md
+++ b/docs/INTERNALS.md
@@ -743,7 +743,7 @@ for HEAD requests, but this handler explicitly returns an empty body.)
 
 **`endpoints_handler`** (`src/routes/core_routes.rs`):
 Serializes the static `API_ENDPOINTS` array into JSON. The array is defined
-at `src/routes/core_routes.rs` and lists all 20 endpoints with their
+at `src/routes/core_routes.rs` and lists all 28 endpoints with their
 path, method, and description.
 
 ### 5.5 Infrastructure Handlers
@@ -878,6 +878,56 @@ pub async fn get_metrics(State(metrics): State<Arc<Metrics>>) -> impl IntoRespon
 
 Uses Axum's `State` extractor to access the shared `Arc<Metrics>`. Returns the
 full snapshot as JSON.
+
+### 5.6 Data & Plugin-Testing Handlers
+
+These handlers exist to give clients a controllable upstream — useful when
+exercising gateway plugins or testing client behavior against deliberately
+shaped responses. The first decodes data, the other three are the "Tier 3
+plugin-testing trio" (response-shaping, payload sizing, slow streaming).
+
+**`base64_handler`** (`src/routes/base64.rs`):
+Decodes the URL-safe base64 string from the path and returns a JSON wrapper
+with the input, the decoded content (via `String::from_utf8_lossy`), an
+`is_utf8` flag derived from `std::str::from_utf8`, and the decoded byte
+length. Standard base64 is attempted as a fallback when the URL-safe decode
+fails (covers cases where a `+` or `/` slipped into a non-URL-safe encode);
+that fallback is best-effort because `/` would also break path routing.
+Input is capped at `MAX_BASE64_INPUT_BYTES` (4096); larger paths return 400
+before any decode work.
+
+**`bytes_handler`** (`src/routes/bytes.rs`):
+Allocates `n` bytes, fills via `rand::thread_rng().fill_bytes()` for maximum
+entropy (so any tampering by an intermediate proxy is observable), and emits
+them with `Content-Type: application/octet-stream`. `n` is capped at
+`MAX_BYTES_RESPONSE_SIZE` (10 MiB) to bound the per-request allocation. The
+metrics layer normalizes `/bytes/:n` to a single bucket so high-cardinality
+`n` values don't blow up the per-endpoint counters.
+
+**`response_headers_handler`** (`src/routes/response_headers.rs`):
+Takes `Query<Vec<(String, String)>>` so duplicate query keys are preserved
+(a `HashMap` would silently collapse them). Each `(key, value)` is validated
+via `HeaderName::from_bytes` and `HeaderValue::from_str`; a single failure
+short-circuits with 400 before any partial response state is built. Builds a
+JSON body that collapses duplicate keys to arrays, then constructs the
+`Response`: removes any default header whose name appears in the user input
+(so user-supplied `content-type` actually replaces the JSON default — the
+intentional mismatch lets you exercise a `response-transformer` plugin), then
+appends each user header in original order so duplicates emit as repeated
+response headers.
+
+**`drip_handler`** (`src/routes/drip.rs`):
+Validates query params (`numbytes`, `duration`, `code`, `delay`) up front —
+once the response body starts streaming, headers are flushed and the status
+can no longer change. Builds a `futures_util::stream::unfold` that emits
+chunks of `*` over `duration` seconds, then wraps it in
+`axum::body::Body::from_stream`. Hyper picks `Transfer-Encoding: chunked`
+automatically because the body has no `Content-Length`. Chunk pacing is
+clamped so emissions are at least ~1 ms apart (tokio timer precision):
+asking for 10 000 bytes over 1 s yields 1 000 chunks of 10 bytes spaced
+1 ms apart, not 10 000 sub-millisecond sleeps that the timer would silently
+coalesce. A trailing sleep is scheduled before the stream ends so the total
+wall-clock time matches the requested duration.
 
 ---
 
@@ -2283,12 +2333,15 @@ Complete listing of all source files with line counts and primary purpose:
 | `src/cli/commands.rs` | `Args`, `CliCommand`, start/stop/status/version handlers |
 | `src/routes/mod.rs` | Routes module re-exports |
 | `src/routes/base64.rs` | `/base64/:encoded` handler and router |
+| `src/routes/bytes.rs` | `/bytes/:n` handler and router |
 | `src/routes/cookies.rs` | `/cookies`, `/cookies/set`, `/cookies/delete` handlers and router |
 | `src/routes/core_routes.rs` | 16 route handlers, `router()`, `EndpointInfo`, `API_ENDPOINTS` |
 | `src/routes/delay.rs` | `/delay/:n` handler and router |
+| `src/routes/drip.rs` | `/drip` handler, streaming body builder, and router |
 | `src/routes/healthz.rs` | `/healthz` handler and router |
 | `src/routes/metrics.rs` | `/metrics` handler (stateful, `State<Arc<Metrics>>`) |
 | `src/routes/redirect.rs` | `/redirect/:n` handler and router |
+| `src/routes/response_headers.rs` | `/response-headers` handler and router (duplicate-key preserving) |
 | `src/server/mod.rs` | `run_server()` — top-level orchestrator |
 | `src/server/http.rs` | HTTP/HTTPS listener setup, TCP socket config, HTTP builder config |
 | `src/server/tcp.rs` | TCP echo listener setup (accept loop) |
@@ -2300,7 +2353,7 @@ Complete listing of all source files with line counts and primary purpose:
 | `src/tcp_udp_handlers.rs` | TCP echo loop, UDP echo with exponential backoff |
 | `src/utils/mod.rs` | Utils module re-exports |
 | `src/utils/config.rs` | `Config`, `ChaosConfig`, loading, validation, `load_env_var!` |
-| `src/utils/constants.rs` | All hardcoded constants (15 values) |
+| `src/utils/constants.rs` | All hardcoded constants (19 values) |
 | `src/utils/error_response.rs` | `format_error_response()` |
 | `src/utils/json_response.rs` | `format_json_response()`, `format_json_response_with_timing()` |
 | `src/utils/metrics.rs` | `Metrics`, `TimeBucket`, rolling window, snapshot structs |
@@ -2309,7 +2362,7 @@ Complete listing of all source files with line counts and primary purpose:
 | `src/utils/timing.rs` | `RequestTiming` struct |
 | `benches/response_benchmarks.rs` | Criterion microbenchmarks for response building functions |
 | `benches/endpoint_benchmarks.rs` | Criterion async benchmarks for full endpoint request cycles via `tower::oneshot` |
-| `tests/integration.rs` | Integration tests — real HTTP server per test via `reqwest` (12 tests) |
+| `tests/integration.rs` | Integration tests — real HTTP server per test via `reqwest` (24 tests) |
 | `debian/man/rucho.1` | Man page (roff format) — installed to `/usr/share/man/man1/` via `.deb` |
 
 ---


### PR DESCRIPTION
## Summary
End-of-session sweep to close every doc-staleness gap I could find after the run of recent endpoint PRs (#113–#117).

## Changes

### `README.md`
Features list adds the five entries that drifted in over the last three sessions:
- `/base64` decoding
- Tier 3 plugin-testing trio: `/response-headers`, `/bytes/:n`, `/drip`
- Configurable `max_body_size_bytes` request body cap

### `CHANGELOG.md`
- New **Fixed** entry under `[Unreleased]` for the `/endpoints` runtime-list bugfix landed in PR #116. The static `API_ENDPOINTS` array had been missing `/base64` (since PR #105) and the three Tier 3 endpoints (since #113–#115), so the runtime discoverability layer lagged the actual router.

### `docs/INTERNALS.md`
- **Section 5.4 `endpoints_handler` text:** *"lists all 20 endpoints"* → *"all 28 endpoints"* — was off-by-eight after the four new entries
- **New section 5.6 "Data & Plugin-Testing Handlers"** — deep descriptions of `base64_handler`, `bytes_handler`, `response_headers_handler`, `drip_handler`. Section 5 had been silent on all four despite each appearing in the 5.1 table
- **Source-file index** gains rows for `src/routes/bytes.rs`, `src/routes/drip.rs`, `src/routes/response_headers.rs`
- **Source-file index counts:**
  - constants `15 values` → `19 values` (added `MAX_BASE64_INPUT_BYTES`, `DEFAULT_MAX_BODY_SIZE_BYTES`, `MAX_BYTES_RESPONSE_SIZE`, `MAX_DRIP_NUMBYTES`)
  - integration tests `(12 tests)` → `(24 tests)` — doubled coverage across recent endpoint PRs

## Out of scope (intentional)
- `CONTRIBUTING.md` "Rust 1.70+" — actual MSRV is unpinned; tracked as a separate Tier 8 roadmap item
- `Dockerfile` `rust:1.84-bookworm` — same MSRV question
- Dependabot config (PR #117) is contributor-side scaffolding with no behavior change for API consumers — skipped from CHANGELOG per Keep-a-Changelog scope

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test` — 112 unit + 24 integration + 1 doc, all passing
- [x] No source code changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)