### PR TITLE
refactor: Cache per-thread RNG in chaos middleware, tidy unwraps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `/bytes/:n` endpoint — returns `n` random bytes as `application/octet-stream`. Capped at 10 MiB; larger values return 400. Metrics path normalized to `/bytes/:n` to prevent cardinality explosion. Targets gateway response-buffering, binary-integrity, and compression-plugin testing.
 - `/drip` endpoint — streams `numbytes` bytes of `*` evenly over `duration` seconds via chunked transfer encoding. Optional `code` overrides the response status; optional `delay` waits before the first byte. Caps: `numbytes` ≤ 10 000, `duration` and `delay` ≤ 300 s. Internally clamps chunk pacing to ~1 ms intervals to respect timer precision. Designed for exercising inter-byte (read/send) timeouts and streaming-vs-buffering behavior in gateways.
 
+### Changed
+- Chaos middleware now uses a per-thread cached RNG (`thread_local!` `StdRng`, seeded once from entropy) instead of constructing and re-seeding a `StdRng` from `thread_rng()` on every request. The v1.4.6 changelog described this optimization, but the implementation had continued to re-seed per request — this lands it for real. Internal only; chaos injection behavior is unchanged.
+
 ### Fixed
 - `/anything` handler no longer reads the full request body with `usize::MAX` limit — closes an OOM vector. `anything_handler` now uses the `Bytes` extractor which honors the configured `max_body_size_bytes`.
 - `/ip` no longer returns `"unknown"` when a request arrives without `X-Forwarded-For` or `X-Real-IP` headers. The server now binds with `into_make_service_with_connect_info::<SocketAddr>()`, letting `ip_handler` fall back to the peer address from the TCP connection.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -158,12 +158,12 @@
 ### Correctness / Hot Paths
 - [ ] Metrics lock contention — swap `RwLock<HashMap>` for `DashMap<String, AtomicU64>` or sharded atomics. Current implementation serializes every recorded request on a write lock (`src/utils/metrics.rs`)
 - [ ] Metrics cardinality cap for `/cookies/{action}` — clients can force unbounded growth by sending arbitrary subpaths. Bucket unknown `action` values to `/cookies/other` (`src/server/metrics_layer.rs:52`)
-- [ ] Chaos RNG: replace per-request `StdRng::from_rng(rand::thread_rng())` with cached `thread_local!` `StdRng` or use `rand::thread_rng()` directly — the v1.4.6 CHANGELOG claims this was optimized but the per-request seed is still present (`src/server/chaos_layer.rs:29`)
+- [x] Chaos RNG: now uses a per-thread cached `thread_local!` `StdRng` (seeded once via `from_entropy`, accessed via `with` so the borrow never crosses an `.await` — keeping the future `Send`) instead of re-seeding per request. Lands the optimization the v1.4.6 CHANGELOG had claimed but never implemented (`src/server/chaos_layer.rs`)
 - [ ] Replace `RwLock<usize>` around `current_bucket_idx` with `AtomicUsize` (`src/utils/metrics.rs:78`)
 - [ ] Remove dead 500 branch in `endpoints_handler` — `serde_json::to_value` on `&'static [EndpointInfo]` is infallible (`src/routes/core_routes.rs:454-465`)
 
 ### `.unwrap()` Hygiene
-- [ ] Replace `.unwrap()` in `src/server/chaos_layer.rs:49-50, 55, 107, 118` with `.expect("infallible: static response builder")` so intent matches CLAUDE.md "no unwrap in production" rule
+- [x] Replaced `.unwrap()` in `src/server/chaos_layer.rs` (response builder + the three `x-chaos` header inserts, the latter via a shared `chaos_header()` helper) with `.expect("infallible: …")` — matches CLAUDE.md "no unwrap in production" rule
 - [ ] Replace `.unwrap()` in `src/routes/core_routes.rs:431, 795` (head_handler, options_handler response builders) with `.expect(...)`
 
 ### DRY & Refactoring

--- a/src/server/chaos_layer.rs
+++ b/src/server/chaos_layer.rs
@@ -11,9 +11,33 @@ use axum::response::Response;
 use http::StatusCode;
 use rand::rngs::StdRng;
 use rand::{Rng, SeedableRng};
+use std::cell::RefCell;
 use std::sync::Arc;
 
 use crate::utils::config::ChaosConfig;
+
+thread_local! {
+    /// Per-thread RNG for chaos rolls, seeded once from OS entropy and reused
+    /// across requests. Avoids re-seeding a `StdRng` on every request (the prior
+    /// per-call `StdRng::from_rng(thread_rng())` cost). Accessed only via `with`,
+    /// so the borrow is never held across an `.await` — a `!Send` value held
+    /// across `.await` would make the middleware future `!Send`, which axum rejects.
+    static CHAOS_RNG: RefCell<StdRng> = RefCell::new(StdRng::from_entropy());
+}
+
+/// Draws a uniform probability in `[0, 1)` from the per-thread chaos RNG.
+fn roll_probability() -> f64 {
+    CHAOS_RNG.with(|rng| rng.borrow_mut().gen::<f64>())
+}
+
+/// Builds the `X-Chaos` response header value from the applied-effects list.
+/// Infallible: the value is a comma-joined list of static ASCII tokens.
+fn chaos_header(applied: &[&str]) -> http::HeaderValue {
+    applied
+        .join(",")
+        .parse()
+        .expect("infallible: x-chaos header value is ASCII")
+}
 
 /// Middleware that injects chaos behaviors based on configuration.
 ///
@@ -26,12 +50,12 @@ pub async fn chaos_middleware(
     next: Next,
     chaos: Arc<ChaosConfig>,
 ) -> Response<Body> {
-    let mut rng = StdRng::from_rng(rand::thread_rng()).expect("thread_rng seeding");
     let mut applied: Vec<&str> = Vec::new();
 
     // 1. Roll for failure — short-circuit with error response
-    if chaos.has_failure() && rng.gen::<f64>() < chaos.failure_rate {
-        let code_idx = rng.gen_range(0..chaos.failure_codes.len());
+    if chaos.has_failure() && roll_probability() < chaos.failure_rate {
+        let code_idx =
+            CHAOS_RNG.with(|rng| rng.borrow_mut().gen_range(0..chaos.failure_codes.len()));
         let status_code = chaos.failure_codes[code_idx];
         applied.push("failure");
 
@@ -46,22 +70,25 @@ pub async fn chaos_middleware(
         let mut response = Response::builder()
             .status(StatusCode::from_u16(status_code).unwrap_or(StatusCode::INTERNAL_SERVER_ERROR))
             .header("content-type", "application/json")
-            .body(Body::from(serde_json::to_vec_pretty(&body).unwrap()))
-            .unwrap();
+            .body(Body::from(
+                serde_json::to_vec_pretty(&body)
+                    .expect("infallible: serializing static chaos body"),
+            ))
+            .expect("infallible: chaos failure response builder");
 
         if chaos.inform_header {
             response
                 .headers_mut()
-                .insert("x-chaos", applied.join(",").parse().unwrap());
+                .insert("x-chaos", chaos_header(&applied));
         }
 
         return response;
     }
 
     // 2. Roll for delay — sleep before passing to handler
-    if chaos.has_delay() && rng.gen::<f64>() < chaos.delay_rate {
+    if chaos.has_delay() && roll_probability() < chaos.delay_rate {
         let delay_ms = if chaos.delay_ms == "random" {
-            rng.gen_range(0..chaos.delay_max_ms)
+            CHAOS_RNG.with(|rng| rng.borrow_mut().gen_range(0..chaos.delay_max_ms))
         } else {
             chaos.delay_ms.parse::<u64>().unwrap_or(0)
         };
@@ -76,7 +103,7 @@ pub async fn chaos_middleware(
     let response = next.run(request).await;
 
     // 4. Roll for corruption — modify response body
-    if chaos.has_corruption() && rng.gen::<f64>() < chaos.corruption_rate {
+    if chaos.has_corruption() && roll_probability() < chaos.corruption_rate {
         applied.push("corruption");
         let (mut parts, body) = response.into_parts();
 
@@ -94,7 +121,10 @@ pub async fn chaos_middleware(
                     .await
                     .unwrap_or_default();
                 let len = bytes.len();
-                let garbage: Vec<u8> = (0..len).map(|_| rng.gen_range(0x21..0x7F)).collect();
+                let garbage: Vec<u8> = CHAOS_RNG.with(|rng| {
+                    let mut rng = rng.borrow_mut();
+                    (0..len).map(|_| rng.gen_range(0x21u8..0x7F)).collect()
+                });
                 Body::from(garbage)
             }
             _ => body, // Shouldn't happen after validation
@@ -102,9 +132,7 @@ pub async fn chaos_middleware(
 
         // 5. Add X-Chaos header if inform_header enabled and any effect applied
         if chaos.inform_header && !applied.is_empty() {
-            parts
-                .headers
-                .insert("x-chaos", applied.join(",").parse().unwrap());
+            parts.headers.insert("x-chaos", chaos_header(&applied));
         }
 
         return Response::from_parts(parts, corrupted_body);
@@ -113,11 +141,24 @@ pub async fn chaos_middleware(
     // 5. Add X-Chaos header if inform_header enabled and any effect applied (no corruption path)
     if chaos.inform_header && !applied.is_empty() {
         let (mut parts, body) = response.into_parts();
-        parts
-            .headers
-            .insert("x-chaos", applied.join(",").parse().unwrap());
+        parts.headers.insert("x-chaos", chaos_header(&applied));
         return Response::from_parts(parts, body);
     }
 
     response
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn roll_probability_stays_in_unit_interval() {
+        // Exercises the thread-local RNG plumbing: many sequential borrows must
+        // not panic (no overlapping `borrow_mut`) and must keep advancing the RNG.
+        for _ in 0..1000 {
+            let p = roll_probability();
+            assert!((0.0..1.0).contains(&p), "probability out of range: {p}");
+        }
+    }
 }


### PR DESCRIPTION
## Summary
Replaces the per-request `StdRng::from_rng(thread_rng())` re-seed in the chaos middleware with a `thread_local!` cached `StdRng` (seeded once via `from_entropy`), accessed through `.with()` so the borrow never crosses an `.await`.

The original `StdRng` was a deliberate `Send` workaround — the RNG is held across the delay/handler/`to_bytes` await points and `ThreadRng` is `!Send`, so a naive `thread_rng()` swap wouldn't compile. The thread-local approach keeps the middleware future `Send` **and** eliminates the per-request seeding cost.

This finally lands the optimization the v1.4.6 changelog had claimed (*"uses thread-local RNG instead of re-seeding per request"*) but never actually implemented.

## Also
- `.unwrap()` → `.expect("infallible: …")` throughout the file (per the "no unwrap in production" rule), with the three duplicated `x-chaos` header inserts DRY'd into a single `chaos_header()` helper.
- Added a `roll_probability` smoke test.
- CHANGELOG `[Unreleased] → Changed` entry correcting the v1.4.6 claim; ROADMAP Tier 6 chaos items ticked.

## Verification (CI-exact)
- `cargo fmt --all` ✓
- `cargo clippy --all-targets --all-features -- -D warnings` → 0 warnings ✓
- `cargo test --all-features` → 113 unit + 24 integration + 1 doc, 0 failures ✓

Internal perf/hygiene change — chaos injection behavior is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)