### PR TITLE
chore(ci): Add windows-latest cargo check job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,32 @@ jobs:
       - name: Run clippy
         run: cargo clippy --all-targets --all-features -- -D warnings
 
+  check-windows:
+    name: Check (Windows)
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo registry
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+
+      # Compile-only check to catch platform-gated drift (e.g. the
+      # #[cfg(not(target_os = "windows"))] socket2 path in server/http.rs)
+      # without running the full Unix-oriented test suite on Windows.
+      - name: Cargo check
+        run: cargo check --all-targets --all-features
+
   test:
     name: Test
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
Adds a dedicated **`Check (Windows)`** job to CI: a compile-only `cargo check --all-targets --all-features` on `windows-latest`, running in parallel with the existing Linux `check` job (own OS-keyed cargo cache).

## Why
Rucho is developed on WSL (Linux) and CI has only ever run on Linux, so native-Windows compile drift goes undetected — notably the one `#[cfg(not(target_os = "windows"))]` socket2 path in `server/http.rs`. This is the standing Priority #1 in the ROADMAP: zero PR-triage cost, catches the WSL-dev / Linux-CI drift the project has been bitten by before.

Compile-only by design — the Unix-oriented runtime (PID paths, signals) and the full test suite still run on Linux only.

## Note
This is the empirical "does Rucho compile on Windows?" check. If the Windows job surfaces a compile error, the fix goes in this same PR before it's mergeable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)