### PR TITLE
docs: Add "Why rucho?" + Kong Gateway / Kong Mesh upstream guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,19 @@
 [![Release](https://img.shields.io/github/v/release/rumpus/rucho)](https://github.com/rumpus/rucho/releases/latest)
 
 Simple, fast, and scalable HTTP echo server built with Rust and Axum.
-Designed for testing, debugging, and simulating various HTTP behaviors.
+Designed for testing and debugging HTTP behaviors — and for use as a controllable
+upstream behind Kong Gateway or inside Kong Mesh.
+
+## Why rucho?
+
+Rucho is an **echo server first** — a faster, more robust alternative to [httpbin](https://httpbin.org) for inspecting and shaping HTTP requests and responses:
+
+- **Fast & robust** — Rust / Axum / Tokio with zero-copy responses; no interpreter startup and predictable latency under load (vs. Python/Flask httpbin).
+- **Maintained & tested** — the original httpbin is effectively unmaintained; rucho ships an integration + unit test suite and a multi-platform (Linux + Windows) CI matrix.
+- **More than HTTP** — built-in **TCP and UDP** echo listeners, first-class **HTTPS / HTTP-2** via Rustls, and connection/socket tuning that go-httpbin doesn't expose.
+- **Chaos built in** — failure / delay / corruption injection for resilience testing, no sidecar required.
+
+It's also purpose-built as a **controllable testing upstream behind [Kong Gateway](https://konghq.com/products/kong-gateway) or inside [Kong Mesh](https://konghq.com/products/kong-mesh)**: endpoints that deterministically emit the stimuli (status codes, delays, slow streams, redirects, forced content types, byte ranges) you need to observe how the gateway/mesh proxies, transforms, times out, retries, and routes. See **[Using rucho as a Kong upstream](docs/USAGE_EXAMPLES.md#using-rucho-as-a-kong-upstream)**.
 
 ## Features
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -97,7 +97,7 @@ Keep the "fast, robust Rust" promise — hot-path correctness over premature opt
 
 Coverage that backs the "more robust than httpbin" claim, and CI that catches the WSL-dev / Linux-CI drift.
 
-- [ ] **[H]** Add `windows-latest` to the CI matrix for `cargo check` — catches platform-gated drift (e.g. `socket2` `with_retries`); zero PR-triage cost; unambiguous side-project win
+- [x] **[H]** Add `windows-latest` to the CI matrix for `cargo check` — catches platform-gated drift; Rucho confirmed to compile cleanly on Windows (PR #136)
 - [ ] **[H]** `spawn_full_app()` test helper that uses the real `build_app()` — current `spawn_app()` builds a minimal router and misses chaos/metrics middleware regressions
 - [ ] **[M]** Integration-test gaps — `/delay` fires (≥1 s), `HEAD /get`, `/status/500`, response compression, `/metrics` enabled, `/endpoints` shape, malformed-JSON → 400
 - [ ] **[M]** Property tests — chaos probabilities stay within bounds; `/redirect/:n` yields exactly `n` hops; `parse_cookies` never panics on any byte sequence
@@ -126,9 +126,9 @@ Docker/release ergonomics at **single-maintainer scope** — explicitly *not* pr
 
 Tell the dual-mission story and end the doc sprawl.
 
-- [ ] **[H]** "Why rucho?" section at the top of the README — 3–4 lines vs httpbin / go-httpbin / mockoon (speed, robustness, chaos mode, TCP/UDP, production-grade TLS + socket tuning)
-- [ ] **[H]** "Using rucho as a Kong upstream" section + a declarative `kong.yaml` snippet — the secondary-mission story
-- [ ] **[M]** "Using rucho inside Kong Mesh" snippet (Kuma `Dataplane` / service) — completes the secondary identity now that mesh is in scope
+- [x] **[H]** "Why rucho?" section at the top of the README — vs httpbin / go-httpbin (speed, robustness, TCP/UDP, TLS, chaos) + the Kong-upstream pitch (PR #137)
+- [x] **[H]** "Using rucho as a Kong upstream" section + a declarative `kong.yaml` snippet (PR #137)
+- [x] **[M]** "Using rucho in Kong Mesh" snippet — Kuma sidecar injection + a MeshRetry example (PR #137)
 - [ ] **[M]** Deduplicate the project-structure block (one canonical source; README/CONTRIBUTING/INTERNALS currently triplicate it — this ROADMAP no longer renders it either)
 - [ ] **[M]** Deduplicate config-field tables — canonical source is `config_samples/rucho.conf.default`; link, don't re-render
 - [ ] **[M]** Replace `docs/API_REFERENCE.md` with a one-pager linking `/swagger-ui` as canonical + 3–4 example responses (the hand-written table caused the v1.4.4 missing-endpoint fix)
@@ -146,11 +146,13 @@ Tell the dual-mission story and end the doc sprawl.
 
 Ranked by payoff for the dual mission:
 
-1. **`windows-latest` CI matrix** — closes the WSL-dev / Linux-CI drift the memory flags as recurring; zero triage cost
-2. **"Why rucho?" + "rucho as a Kong upstream / in Kong Mesh" docs** — the mission was just clarified; make it real to users (cheapest, highest leverage)
-3. **`spawn_full_app()` real-`build_app()` test helper** — removes a correctness blind spot (chaos/metrics middleware) that undercuts the robustness claim
-4. **Multi-arch Docker image** — small CI change, big UX for Apple-Silicon / ARM mesh nodes
-5. **`/status/:code` reason phrase + `/redirect/:n` `X-Redirect-Count`** — cheap echo-fidelity + gateway-observability wins (two small one-PR-each items)
+1. **`spawn_full_app()` real-`build_app()` test helper** — removes a correctness blind spot (chaos/metrics middleware) that undercuts the robustness claim
+2. **Multi-arch Docker image** — small CI change, big UX for Apple-Silicon / ARM mesh nodes
+3. **`/status/:code` reason phrase + `/redirect/:n` `X-Redirect-Count`** — cheap echo-fidelity + gateway-observability wins (two small one-PR-each items)
+4. **Forced-encoding trio `/gzip`·`/brotli`·`/deflate`** — highest-value remaining endpoint; drives Kong Response-Transformer decode path; codecs already vendored
+5. **Metrics cardinality cap + `/cache` conditional requests** — close the unbounded-metrics-key vector; add conditional-request (304) fidelity
+
+_Done: `windows-latest` CI matrix (PR #136) · "Why rucho?" + Kong upstream/mesh docs (PR #137)._
 
 ---
 

--- a/docs/USAGE_EXAMPLES.md
+++ b/docs/USAGE_EXAMPLES.md
@@ -30,6 +30,8 @@ All examples assume rucho is running at `http://localhost:8080` (the default).
 - [Byte Ranges](#byte-ranges)
 - [Chaos Engineering](#chaos-engineering)
 - [Health Checks & Monitoring](#health-checks--monitoring)
+- [Using rucho as a Kong Upstream](#using-rucho-as-a-kong-upstream)
+- [Using rucho in Kong Mesh](#using-rucho-in-kong-mesh)
 
 ---
 
@@ -1224,4 +1226,95 @@ spec:
           port: 8080
         initialDelaySeconds: 3
         periodSeconds: 5
+```
+
+---
+
+## Using rucho as a Kong Upstream
+
+Point a Kong Gateway route at rucho, then use its deterministic endpoints to exercise plugins and proxy behavior from the upstream side. Declarative (DB-less) config:
+
+```yaml
+# kong.yaml — a route that proxies to rucho as the upstream service
+_format_version: "3.0"
+services:
+  - name: rucho
+    url: http://rucho:8080          # rucho running as a container/service on the same network
+    routes:
+      - name: rucho
+        paths: ["/"]
+    # plugins attached here act on what rucho returns:
+    # - name: response-transformer
+    #   config: { add: { headers: ["X-Proxied-By:kong"] } }
+```
+
+Then drive gateway behavior deterministically:
+
+```bash
+# Does the service/route timeout fire? rucho holds the response for 10s.
+curl -i http://kong:8000/delay/10
+
+# How does the gateway handle a 503 from upstream (retries / circuit breaker)?
+curl -i http://kong:8000/status/503
+
+# Response buffering vs streaming, and Range passthrough:
+curl -i http://kong:8000/bytes/65536
+curl -i -H 'Range: bytes=0-99' http://kong:8000/range/1000000
+
+# Inspect exactly what the gateway forwarded upstream (added / stripped / rewritten headers):
+curl -s http://kong:8000/headers | jq
+```
+
+`/headers` and `/anything` are the workhorses: they echo precisely what reached the upstream, so you can verify what a plugin added, stripped, or rewrote.
+
+## Using rucho in Kong Mesh
+
+In [Kong Mesh](https://docs.konghq.com/mesh/) (built on [Kuma](https://kuma.io/)), run rucho as a plain-HTTP service with sidecar injection. The sidecar provides mTLS, observability, and traffic policies — so rucho stays a simple upstream you point policies at (**don't** enable rucho's own TLS/mTLS inside the mesh; that's the sidecar's job).
+
+```yaml
+# Kubernetes Deployment — Kong Mesh / Kuma sidecar injection
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: rucho
+spec:
+  selector: { matchLabels: { app: rucho } }
+  template:
+    metadata:
+      labels: { app: rucho }
+      annotations:
+        kuma.io/sidecar-injection: enabled    # mesh injects the sidecar (mTLS + observability)
+    spec:
+      containers:
+        - name: rucho
+          image: rumpus/rucho:latest
+          ports:
+            - containerPort: 8080
+              name: http                       # name it `http` so Kuma treats it as L7
+```
+
+Apply a traffic policy, then use rucho's stimulus endpoints to trigger and observe it:
+
+```yaml
+# MeshRetry — retry on 5xx; rucho's /status/503 forces the condition
+apiVersion: kuma.io/v1alpha1
+kind: MeshRetry
+metadata:
+  name: rucho-retry
+  namespace: kong-mesh-system
+spec:
+  targetRef: { kind: Mesh }
+  to:
+    - targetRef: { kind: MeshService, name: rucho }
+      default:
+        http:
+          numRetries: 3
+          retryOn: ["5xx"]
+```
+
+```bash
+# From another meshed pod — observe retries against a forced 503, and
+# MeshTimeout behavior against a held response:
+curl -i http://rucho.default.svc:8080/status/503
+curl -i http://rucho.default.svc:8080/delay/10
 ```


### PR DESCRIPTION
## Summary
ROADMAP Priority #2 — tell the dual-mission story to users.

- **README → "Why rucho?"** — a differentiation section vs httpbin / go-httpbin (fast/robust Rust, maintained + multi-platform CI, TCP/UDP + HTTPS/HTTP-2, built-in chaos) and the controllable-upstream pitch, linking to the Kong guide.
- **USAGE_EXAMPLES → "Using rucho as a Kong Upstream"** — a declarative (DB-less) `kong.yaml` plus endpoint-driven scenarios (timeout via `/delay`, retries/circuit-breaker via `/status/503`, buffering via `/bytes`, Range passthrough via `/range`, and `/headers` to inspect exactly what the gateway forwarded).
- **USAGE_EXAMPLES → "Using rucho in Kong Mesh"** — a Kubernetes Deployment with `kuma.io/sidecar-injection`, a `MeshRetry` policy example, and the key note that the sidecar terminates mTLS so rucho stays plain HTTP (don't enable rucho's own TLS inside the mesh).

## Roadmap bookkeeping (also in this PR)
- Ticked **T4 windows-latest CI** (landed in PR #136 — Rucho compiles cleanly on Windows).
- Ticked the three **T6** doc items completed here.
- Refreshed the Priority Order (next up: `spawn_full_app()`, multi-arch Docker, `/status` reason phrase + `/redirect` `X-Redirect-Count`).

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)