### PR TITLE
feat: /status reason phrase + /redirect X-Redirect-Count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Chaos middleware now uses a per-thread cached RNG (`thread_local!` `StdRng`, seeded once from entropy) instead of constructing and re-seeding a `StdRng` from `thread_rng()` on every request. The v1.4.6 changelog described this optimization, but the implementation had continued to re-seed per request — this lands it for real. Internal only; chaos injection behavior is unchanged.
+- `/status/:code` now returns a JSON body `{ "status", "reason" }` carrying the canonical reason phrase (e.g. `"Not Found"`) instead of an empty body, while the HTTP status line still carries the requested code — an inspection-fidelity improvement over httpbin.
+- `/redirect/:n` now emits an `X-Redirect-Count` response header (remaining hops) on each 302, so clients can observe chain progress without parsing the `Location` URL.
 
 ### Fixed
 - `/anything` handler no longer reads the full request body with `usize::MAX` limit — closes an OOM vector. `anything_handler` now uses the `Bytes` extractor which honors the configured `max_body_size_bytes`.

--- a/README.md
+++ b/README.md
@@ -86,11 +86,11 @@ rucho version  # Display version
 | PATCH   | `/patch`          | Echo request with JSON body                          |
 | DELETE  | `/delete`         | Echo request details                                 |
 | OPTIONS | `/options`        | Return allowed methods                               |
-| ANY     | `/status/:code`   | Return specified HTTP status code                    |
+| ANY     | `/status/:code`   | Return a status code + `{status, reason}` JSON body  |
 | ANY     | `/anything`       | Echo any request                                     |
 | ANY     | `/anything/*path` | Echo any request with path                           |
 | ANY     | `/delay/:n`       | Delay response by n seconds (max 300)                |
-| ANY     | `/redirect/:n`    | Chain of n HTTP 302 redirects (max 20)               |
+| ANY     | `/redirect/:n`    | Chain of n 302s (max 20; `X-Redirect-Count` header)  |
 | GET     | `/cookies`        | Inspect request cookies                              |
 | GET     | `/cookies/set`    | Set cookies via query params and redirect            |
 | GET     | `/cookies/delete` | Delete cookies via query params and redirect         |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -57,7 +57,7 @@ Items are tagged **[H]** / **[M]** / **[L]** by priority.
 
 Make request inspection more correct, complete, and honest than httpbin & go-httpbin.
 
-- [ ] **[H]** `/status/:code` returns the canonical reason phrase in the body (e.g. `"Not Found"` for 404) — httpbin-parity; an inspector should report the phrase, not just the number
+- [x] **[H]** `/status/:code` returns `{ "status", "reason" }` JSON carrying the canonical reason phrase (e.g. "Not Found" for 404) while the status line keeps the requested code — httpbin-parity inspection win (PR #140)
 - [ ] **[M]** Echo HTTP version + TLS info in `/get` / `/anything` (`http_version`, negotiated ALPN/cipher, presented client-cert info when available) — go-httpbin omits this; unique inspection value that doubles as gateway-proxy visibility
 - [ ] **[M]** `/cache` + `/cache/:seconds` — emit `ETag` / `Last-Modified` and honor `If-None-Match` / `If-Modified-Since` → `304`; `/cache/:n` sets `Cache-Control: max-age=n`. Framed as *conditional-request fidelity* (the upstream emits the stimulus; lets you watch a gateway/cache react). Model on `range.rs`; no new deps
 - [ ] **[M]** `parse_cookies` tolerates both `;` and `; ` separators (RFC 6265) — correctness; sloppy cookie parsing is a known httbin/go-httpbin pain point (`src/routes/cookies.rs`)
@@ -72,7 +72,7 @@ Controllable upstream knobs to observe Kong Gateway / Kong Mesh behavior the gat
 
 - [ ] **[M]** Forced content-encoding trio `/gzip`, `/deflate`, `/brotli` — return a JSON body compressed with that codec + the matching `Content-Encoding`, *regardless of `Accept-Encoding`*. Tests Kong's Response-Transformer / RT-Advanced decode-and-rewrite path against an already-encoded upstream body (documented breakage: Kong/kong#13741, #1200). `flate2` + `brotli` are already transitive via tower-http → promote to direct deps (near-zero cost). One PR (trio). Fixed paths → no metrics-normalize change
 - [ ] **[M]** `X-Response-Time` response header from `RequestTiming` — matches Kong's own plugin output; lets you compare upstream-measured vs gateway-measured latency
-- [ ] **[M]** `/redirect/:n` emits an `X-Redirect-Count` header — observe hop number without parsing the URL; useful watching Kong follow-redirect behavior
+- [x] **[M]** `/redirect/:n` emits an `X-Redirect-Count` header (remaining hops) on each 302 — observe chain progress without parsing the URL (PR #140)
 - [ ] **[M]** Connection-control knob (e.g. `/anything?connection=close`) — force upstream `Connection: close` per request to observe Kong connection pooling / keep-alive reuse; the gateway cannot self-generate upstream teardown
 - [ ] **[L]** mTLS — `ssl_ca_cert` config so the upstream *requires & verifies a client cert*. This is the way to test Kong's **upstream**-mTLS configuration (the gateway must present a cert the upstream demands). Distinct from mesh mTLS, which the sidecar terminates (see Non-Goals). Low priority — needs rustls client-cert verification
 - [ ] **[L]** Investigate a slow-headers / slow-first-byte knob distinct from `/delay` and `/drip` — to exercise Kong upstream `read_timeout` vs `connect_timeout` separately. *Validate it isn't redundant with `/drip` (inter-byte) before building*
@@ -146,13 +146,13 @@ Tell the dual-mission story and end the doc sprawl.
 
 Ranked by payoff for the dual mission:
 
-1. **`/status/:code` reason phrase + `/redirect/:n` `X-Redirect-Count`** — cheap echo-fidelity + gateway-observability wins (two small one-PR-each items)
-2. **Forced-encoding trio `/gzip`·`/brotli`·`/deflate`** — highest-value remaining endpoint; drives Kong Response-Transformer decode path; codecs already vendored
-3. **Metrics cardinality cap + `/cache` conditional requests** — close the unbounded-metrics-key vector; add conditional-request (304) fidelity
-4. **`/cookies/set` attribute flags + `parse_cookies` RFC tolerance** — echo-fidelity cookie correctness
-5. **`/healthz/ready` + `/healthz/live` + request-ID middleware** — K8s/mesh probe parity + correlation IDs
+1. **Forced-encoding trio `/gzip`·`/brotli`·`/deflate`** — highest-value remaining endpoint; drives Kong Response-Transformer decode path; codecs already vendored
+2. **Metrics cardinality cap + `/cache` conditional requests** — close the unbounded-metrics-key vector; add conditional-request (304) fidelity
+3. **`/cookies/set` attribute flags + `parse_cookies` RFC tolerance** — echo-fidelity cookie correctness
+4. **`/healthz/ready` + `/healthz/live` + request-ID middleware** — K8s/mesh probe parity + correlation IDs
+5. **`log_format = json` + read-only-FS compat** — structured logging + container/mesh deploy robustness
 
-_Done: `windows-latest` CI matrix (PR #136) · "Why rucho?" + Kong upstream/mesh docs (PR #137) · `spawn_full_app()` + library refactor (PR #138) · multi-arch Docker (PR #139)._
+_Done: `windows-latest` CI matrix (PR #136) · "Why rucho?" + Kong upstream/mesh docs (PR #137) · `spawn_full_app()` + library refactor (PR #138) · multi-arch Docker (PR #139) · `/status` reason phrase + `/redirect` `X-Redirect-Count` (PR #140)._
 
 ---
 

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -262,7 +262,7 @@ Returns the specified HTTP status code. Accepts any HTTP method.
 |-----------|------|-------------|
 | `code` | u16 | HTTP status code to return (e.g. `200`, `404`, `503`) |
 
-**Response:** The specified status code with an empty body.
+**Response:** The specified status code, with a JSON body `{ "status": <code>, "reason": "<canonical reason phrase>" }` (e.g. `{ "status": 404, "reason": "Not Found" }`). Unlike httpbin's empty body, the reason phrase is echoed for inspection.
 
 **Error:** `400 Bad Request` if the code is not a valid HTTP status code.
 
@@ -333,7 +333,7 @@ Returns a chain of HTTP 302 redirects that decrements on each hop.
 
 | Status | Condition | Description |
 |--------|-----------|-------------|
-| `302 Found` | `n >= 1` | `Location` header points to `/redirect/{n-1}` or `/get` when `n=1` |
+| `302 Found` | `n >= 1` | `Location` → `/redirect/{n-1}` (or `/get` when `n=1`); `X-Redirect-Count` header carries the remaining hop count |
 | `200 OK` | `n == 0` | Plain text "Redirect complete" |
 | `400 Bad Request` | `n > 20` | Exceeds maximum allowed hops |
 

--- a/src/routes/core_routes.rs
+++ b/src/routes/core_routes.rs
@@ -314,8 +314,15 @@ pub async fn status_handler(
     axum::extract::Path(code): axum::extract::Path<u16>,
     _method: axum::http::Method,
 ) -> Response {
-    StatusCode::from_u16(code)
-        .unwrap_or(StatusCode::BAD_REQUEST)
+    let status = StatusCode::from_u16(code).unwrap_or(StatusCode::BAD_REQUEST);
+    let reason = status.canonical_reason().unwrap_or("Unknown Status");
+    // Echo the canonical reason phrase in the body (an inspection-fidelity win
+    // over httpbin, which returns an empty body) while the HTTP status line
+    // still carries the requested code.
+    (
+        status,
+        Json(json!({ "status": status.as_u16(), "reason": reason })),
+    )
         .into_response()
 }
 

--- a/src/routes/redirect.rs
+++ b/src/routes/redirect.rs
@@ -2,7 +2,7 @@
 
 use crate::utils::constants::MAX_REDIRECT_HOPS;
 use axum::{
-    http::{header, StatusCode},
+    http::{header, HeaderName, StatusCode},
     response::{IntoResponse, Response},
     routing::any,
     Router,
@@ -52,7 +52,16 @@ pub async fn redirect_handler(axum::extract::Path(n): axum::extract::Path<u32>) 
         format!("/redirect/{}", n - 1)
     };
 
-    (StatusCode::FOUND, [(header::LOCATION, location)]).into_response()
+    // X-Redirect-Count exposes the remaining hop count so a client can observe
+    // chain progress without parsing the Location URL.
+    (
+        StatusCode::FOUND,
+        [
+            (header::LOCATION, location),
+            (HeaderName::from_static("x-redirect-count"), n.to_string()),
+        ],
+    )
+        .into_response()
 }
 
 /// Creates and returns the Axum router for the redirect endpoint.
@@ -82,6 +91,18 @@ mod tests {
             response.headers().get(header::LOCATION).unwrap(),
             "/redirect/2"
         );
+    }
+
+    #[tokio::test]
+    async fn test_redirect_emits_count_header() {
+        let app = router();
+        let response = app
+            .oneshot(Request::get("/redirect/3").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::FOUND);
+        assert_eq!(response.headers().get("x-redirect-count").unwrap(), "3");
     }
 
     #[tokio::test]

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -224,6 +224,9 @@ async fn test_status_codes() {
     let base = spawn_app().await;
     let resp = reqwest::get(format!("{base}/status/418")).await.unwrap();
     assert_eq!(resp.status(), 418);
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(body["status"], 418);
+    assert_eq!(body["reason"], "I'm a teapot");
 }
 
 #[tokio::test]
@@ -244,6 +247,14 @@ async fn test_redirect_chain() {
     assert_eq!(
         resp.headers().get("location").unwrap().to_str().unwrap(),
         "/redirect/2"
+    );
+    assert_eq!(
+        resp.headers()
+            .get("x-redirect-count")
+            .unwrap()
+            .to_str()
+            .unwrap(),
+        "3"
     );
 }
 


### PR DESCRIPTION
## Summary
ROADMAP Priority #1 — two small echo-fidelity / gateway-observability enhancements to existing endpoints (bundled as one focused PR).

- **`/status/:code`** now returns a JSON body `{ "status": <code>, "reason": "<canonical phrase>" }` (e.g. `{ "status": 404, "reason": "Not Found" }`) while the HTTP status line still carries the requested code. httpbin returns an empty body — echoing the reason phrase is an inspection-fidelity win.
- **`/redirect/:n`** now emits an **`X-Redirect-Count`** header (remaining hops) on each 302, so a client can observe chain progress without parsing the `Location` URL — handy when watching how Kong follows/handles a redirect chain.

## Tests
- Unit: `test_redirect_emits_count_header` (302 → `X-Redirect-Count: 3`).
- Integration: `test_status_codes` now asserts the `{status, reason}` body (418 → "I'm a teapot"); `test_redirect_chain` asserts `X-Redirect-Count: 3`.

## Verification (CI-exact)
`cargo fmt` ✓ · `clippy --all-targets --all-features -- -D warnings` → 0 ✓ · `test --all-features` → **136 unit + 35 integration + 1 doc**, 0 failures ✓.

Docs: README endpoint table, `docs/API_REFERENCE.md` (`/status` + `/redirect`), CHANGELOG, ROADMAP ticks + Priority Order refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)