### PR TITLE
chore(ci): Build amd64-only in PR CI; keep multi-arch in release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,21 +149,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
-
-      # Build for both release platforms (no push) so arm64 Dockerfile breakage
-      # is caught on PRs, not only at release time. Cached via GHA to amortize
-      # the emulated arm64 build across runs.
-      - name: Build Docker image (multi-arch)
-        uses: docker/build-push-action@v7
-        with:
-          context: .
-          platforms: linux/amd64,linux/arm64
-          push: false
-          tags: rucho:ci-test
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+      # Fast amd64-only sanity build on PRs. The multi-arch (amd64+arm64) image
+      # is built and pushed by release.yml at release time — the slow emulated
+      # arm64 build runs once per release on a free runner, not on every PR.
+      - name: Build Docker image
+        run: docker build -t rucho:ci-test .

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -110,7 +110,7 @@ Coverage that backs the "more robust than httpbin" claim, and CI that catches th
 
 Docker/release ergonomics at **single-maintainer scope** — explicitly *not* production-team tooling (see `feedback_side_project_tooling_scope.md`).
 
-- [x] **[H]** Multi-arch Docker image (`linux/amd64,linux/arm64`) via `docker buildx` + QEMU — release pushes a multi-arch manifest; CI builds both platforms (no push) to catch arm64 breakage on PRs (PR #139)
+- [x] **[H]** Multi-arch Docker image (`linux/amd64,linux/arm64`) via `docker buildx` + QEMU — `release.yml` pushes a multi-arch manifest at release time; PR CI does a fast amd64-only sanity build (arm64 validated at release, so PRs stay fast) (PRs #139, #141)
 - [ ] **[M]** `/healthz/ready` + `/healthz/live` — distinct K8s/mesh readiness vs liveness probes
 - [ ] **[M]** Request-ID middleware — generate & return `X-Request-Id` on every response (pairs with gateway/mesh tracing as a correlation ID)
 - [ ] **[M]** `log_format = json` config — `tracing_subscriber::fmt().json()` for structured-logging mesh deployments (Loki/Datadog/ELK)


### PR DESCRIPTION
## Summary
Follow-up to the multi-arch work (#139): the per-PR CI Docker build was taking **~56 min** (the `arm64` half under QEMU emulation). This reverts the PR `Docker Build` job to a **fast amd64-only** build (~2 min). `release.yml` is unchanged and still publishes the full **`linux/amd64` + `linux/arm64`** manifest at release time.

## Why
`rumpus/rucho` is a public repo on standard GitHub-hosted runners, so CI is **free either way** (confirmed against the GitHub Actions billing docs) — this is purely a **PR-feedback-speed** win, not a cost one. The tradeoff: arm64-build breakage now surfaces at release instead of on the PR. That's acceptable — it's the same Rust/Debian build on a multi-arch base image, so arm64-specific *build* breaks are rare, and the release build would catch (and block on) one before publishing.

The published image is unchanged — ARM users still get a native image from releases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)