### PR TITLE
fix: Handle SIGTERM for graceful shutdown, not just SIGINT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `/anything` handler no longer reads the full request body with `usize::MAX` limit — closes an OOM vector. `anything_handler` now uses the `Bytes` extractor which honors the configured `max_body_size_bytes`.
 - `/ip` no longer returns `"unknown"` when a request arrives without `X-Forwarded-For` or `X-Real-IP` headers. The server now binds with `into_make_service_with_connect_info::<SocketAddr>()`, letting `ip_handler` fall back to the peer address from the TCP connection.
 - `/endpoints` runtime list now includes `/base64`, `/bytes/:n`, `/response-headers`, and `/drip`. These had been missing from the `API_ENDPOINTS` static since each endpoint was added, so the runtime discoverability layer lagged the actual router.
+- Graceful shutdown now also triggers on **SIGTERM** (Unix), not just SIGINT/Ctrl+C. Container runtimes (Docker, Kubernetes, Kong Mesh / Kuma) stop a process with SIGTERM; previously that bypassed the graceful drain and hard-killed in-flight requests. `shutdown_signal` now races `ctrl_c` with `tokio::signal::unix` `SignalKind::terminate()` and logs which signal fired. Non-Unix targets keep SIGINT-only behavior (the SIGTERM branch is compiled out).
 
 ## [1.4.6] - 2026-02-17
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ It's also purpose-built as a **controllable testing upstream behind [Kong Gatewa
 - CLI for server management (start, stop, status)
 - Configuration via files and environment variables
 - Docker and systemd support
-- Graceful shutdown handling
+- Graceful shutdown on SIGINT + SIGTERM (drains in-flight requests; container/mesh-friendly)
 
 ## Quick Start
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -20,7 +20,7 @@ Items are tagged **[H]** / **[M]** / **[L]** by priority.
 - [x] `/healthz` — health check
 - [x] `/endpoints` — self-documenting endpoint list
 - [x] `/uuid`, `/ip` (peer-address fallback), `/user-agent`, `/headers`
-- [x] Pretty-printed JSON output; graceful shutdown on **SIGINT** (SIGTERM handler pending — see T5); CLI (start/stop/status/version)
+- [x] Pretty-printed JSON output; graceful shutdown on **SIGINT + SIGTERM** (drains in-flight requests, 5s grace); CLI (start/stop/status/version)
 
 ### Endpoints (echo-fidelity + upstream behaviors)
 - [x] `/redirect/:n` — chained 302 redirects (max 20 hops)
@@ -114,7 +114,7 @@ Coverage that backs the "more robust than httpbin" claim, and CI that catches th
 Docker/release ergonomics at **single-maintainer scope** — explicitly *not* production-team tooling (see `feedback_side_project_tooling_scope.md`).
 
 - [x] **[H]** Multi-arch Docker image (`linux/amd64,linux/arm64`) via `docker buildx` + QEMU — `release.yml` pushes a multi-arch manifest at release time; PR CI does a fast amd64-only sanity build (arm64 validated at release, so PRs stay fast) (PRs #139, #141)
-- [ ] **[H]** SIGTERM graceful-shutdown handler — `shutdown.rs` handles only SIGINT (`ctrl_c`); Docker/K8s/Kong-Mesh terminate with **SIGTERM**, which currently bypasses the graceful drain. Race `ctrl_c` with `tokio::signal::unix` `SignalKind::terminate()`. (Audit finding; the "Completed" SIGINT/SIGTERM claim was corrected.)
+- [x] **[H]** SIGTERM graceful-shutdown handler — `shutdown.rs` now races `ctrl_c` with `tokio::signal::unix` `SignalKind::terminate()`, so Docker/K8s/Kong-Mesh SIGTERM drains in-flight requests (5s grace) instead of hard-killing. Unix-gated; non-Unix keeps SIGINT-only (PR #148)
 - [x] **[M]** Request-ID middleware — sets `X-Request-Id` on every response (propagates a non-blank inbound id, else mints UUID v4; outermost layer; set-if-absent so handlers like `/response-headers` win). `request_id_enabled` toggle, default on (PR #147)
 - [ ] **[M]** `log_format = json` config — `tracing_subscriber::fmt().json()` for structured-logging mesh deployments (Loki/Datadog/ELK)
 - [ ] **[M]** Read-only-filesystem compatibility — PID path `/var/run/rucho` may break under `--read-only` Docker; make it tolerant/configurable (also the likely source of the stray `C:\var\run` artifact on Windows)
@@ -151,12 +151,11 @@ Tell the dual-mission story and end the doc sprawl.
 
 Ranked by payoff for the dual mission:
 
-1. **SIGTERM graceful-shutdown handler** — a shipped-but-broken Completed claim: Docker/K8s/Kong-Mesh send SIGTERM, which bypasses the current SIGINT-only drain. Small fix, high deploy-realism payoff
-2. **`log_format = json` + read-only-FS PID compat** — structured logging + `--read-only` container/mesh robustness (one config-surface PR)
-3. **Echo HTTP version + TLS info in `/get`/`/anything`** — inspection fidelity beyond go-httpbin
-4. **`X-Response-Time` header from `RequestTiming`** — compare upstream- vs gateway-measured latency
+1. **`log_format = json` + read-only-FS PID compat** — structured logging + `--read-only` container/mesh robustness (one config-surface PR)
+2. **Echo HTTP version + TLS info in `/get`/`/anything`** — inspection fidelity beyond go-httpbin
+3. **`X-Response-Time` header from `RequestTiming`** — compare upstream- vs gateway-measured latency
 
-_Done: `windows-latest` CI (#136) · "Why rucho?" + Kong docs (#137) · `spawn_full_app()` + lib refactor (#138) · multi-arch Docker (#139) · `/status` + `/redirect` (#140) · amd64-only PR CI (#141) · forced-encoding trio (#142) · metrics cardinality cap (#143) · `/cache` (#144) · cookie fidelity (#145) · ROADMAP reconcile (#146) · request-id middleware (#147)._
+_Done: `windows-latest` CI (#136) · "Why rucho?" + Kong docs (#137) · `spawn_full_app()` + lib refactor (#138) · multi-arch Docker (#139) · `/status` + `/redirect` (#140) · amd64-only PR CI (#141) · forced-encoding trio (#142) · metrics cardinality cap (#143) · `/cache` (#144) · cookie fidelity (#145) · ROADMAP reconcile (#146) · request-id middleware (#147) · SIGTERM shutdown (#148)._
 
 ---
 

--- a/docs/INTERNALS.md
+++ b/docs/INTERNALS.md
@@ -107,7 +107,7 @@ rucho (crate root)
   |   +-- http.rs            # HTTP/HTTPS listener setup, TCP/HTTP config
   |   +-- tcp.rs             # TCP echo listener setup
   |   +-- udp.rs             # UDP echo listener setup
-  |   +-- shutdown.rs        # Ctrl+C graceful shutdown
+  |   +-- shutdown.rs        # SIGINT/SIGTERM graceful shutdown
   |   +-- chaos_layer.rs     # Chaos engineering middleware
   |   +-- metrics_layer.rs   # Metrics recording middleware
   |   +-- timing_layer.rs    # Request timing middleware
@@ -2251,22 +2251,42 @@ become `"<invalid utf8>"`.
 
 ## 13. Graceful Shutdown
 
-**File:** `src/server/shutdown.rs` (17 lines total)
+**File:** `src/server/shutdown.rs`
 
 ```rust
 pub async fn shutdown_signal(handle: Handle) {
-    signal::ctrl_c()
-        .await
-        .expect("failed to install Ctrl+C handler");
-    tracing::info!("Signal received, starting graceful shutdown");
-    handle.graceful_shutdown(Some(Duration::from_secs(5)));
+    let ctrl_c = async {
+        signal::ctrl_c().await.expect("failed to install Ctrl+C handler");
+    };
+
+    #[cfg(unix)]
+    let terminate = async {
+        signal::unix::signal(signal::unix::SignalKind::terminate())
+            .expect("failed to install SIGTERM handler")
+            .recv()
+            .await;
+    };
+    #[cfg(not(unix))]
+    let terminate = std::future::pending::<()>();
+
+    let signal = tokio::select! {
+        _ = ctrl_c => "SIGINT",
+        _ = terminate => "SIGTERM",
+    };
+
+    tracing::info!("{signal} received, starting graceful shutdown");
+    handle.graceful_shutdown(Some(SHUTDOWN_GRACE)); // 5s
 }
 ```
 
 **Behavior:**
 
-1. `signal::ctrl_c().await` — blocks until Ctrl+C is received.
-2. Calls `handle.graceful_shutdown(Some(Duration::from_secs(5)))` on the
+1. Races two signal futures with `tokio::select!` — **SIGINT** (Ctrl+C) and,
+   on Unix, **SIGTERM**. Container runtimes (Docker, Kubernetes, Kong Mesh /
+   Kuma) stop a process with SIGTERM, so handling it is what makes the drain
+   fire under `docker stop` / pod eviction. On non-Unix targets the SIGTERM
+   branch is a never-ready `pending()` future and is effectively compiled out.
+2. Calls `handle.graceful_shutdown(Some(SHUTDOWN_GRACE))` (5s) on the
    shared `axum_server::Handle`.
 3. This tells all HTTP/HTTPS servers sharing this handle to:
    - Stop accepting new connections.
@@ -2441,7 +2461,7 @@ Complete listing of all source files with line counts and primary purpose:
 | `src/server/http.rs` | HTTP/HTTPS listener setup, TCP socket config, HTTP builder config |
 | `src/server/tcp.rs` | TCP echo listener setup (accept loop) |
 | `src/server/udp.rs` | UDP socket binding and listener setup |
-| `src/server/shutdown.rs` | `shutdown_signal()` — Ctrl+C with 5s grace period |
+| `src/server/shutdown.rs` | `shutdown_signal()` — SIGINT/SIGTERM with 5s grace period |
 | `src/server/chaos_layer.rs` | Chaos engineering middleware (failure/delay/corruption) |
 | `src/server/metrics_layer.rs` | Metrics recording middleware + path normalization |
 | `src/server/timing_layer.rs` | Request timing middleware |

--- a/src/server/shutdown.rs
+++ b/src/server/shutdown.rs
@@ -4,14 +4,77 @@ use axum_server::Handle;
 use std::time::Duration;
 use tokio::signal;
 
-/// Listens for a Ctrl+C signal to initiate graceful shutdown.
+/// Grace period for in-flight requests to complete before forced shutdown.
+const SHUTDOWN_GRACE: Duration = Duration::from_secs(5);
+
+/// Listens for a shutdown signal and initiates graceful shutdown.
 ///
-/// When a signal is received, it triggers graceful shutdown on the provided
-/// `Handle` with a 5-second timeout for in-flight requests.
+/// Resolves when either **SIGINT** (Ctrl+C) or, on Unix, **SIGTERM** is
+/// received, then triggers graceful shutdown on the provided `Handle` with a
+/// 5-second timeout for in-flight requests.
+///
+/// SIGTERM handling matters because container runtimes (Docker, Kubernetes,
+/// Kong Mesh / Kuma sidecars) stop a process by sending SIGTERM, *not* SIGINT.
+/// Without it, the default SIGTERM disposition hard-kills the process and drops
+/// in-flight requests instead of draining them. On non-Unix targets only SIGINT
+/// is available, so the SIGTERM branch is compiled out.
 pub async fn shutdown_signal(handle: Handle) {
-    signal::ctrl_c()
-        .await
-        .expect("failed to install Ctrl+C handler");
-    tracing::info!("Signal received, starting graceful shutdown");
-    handle.graceful_shutdown(Some(Duration::from_secs(5)));
+    let ctrl_c = async {
+        signal::ctrl_c()
+            .await
+            .expect("failed to install Ctrl+C handler");
+    };
+
+    #[cfg(unix)]
+    let terminate = async {
+        signal::unix::signal(signal::unix::SignalKind::terminate())
+            .expect("failed to install SIGTERM handler")
+            .recv()
+            .await;
+    };
+
+    // No SIGTERM on non-Unix platforms; this branch never fires there.
+    #[cfg(not(unix))]
+    let terminate = std::future::pending::<()>();
+
+    let signal = tokio::select! {
+        _ = ctrl_c => "SIGINT",
+        _ = terminate => "SIGTERM",
+    };
+
+    tracing::info!("{signal} received, starting graceful shutdown");
+    handle.graceful_shutdown(Some(SHUTDOWN_GRACE));
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::*;
+
+    /// Sending SIGTERM must resolve `shutdown_signal` and initiate graceful
+    /// shutdown — the regression this module exists to prevent (the handler
+    /// previously listened for Ctrl+C/SIGINT only).
+    #[tokio::test]
+    async fn sigterm_triggers_graceful_shutdown() {
+        let handle = Handle::new();
+        let task = tokio::spawn(shutdown_signal(handle.clone()));
+
+        // Let the spawned task be polled so the SIGTERM handler is installed
+        // before we raise the signal (otherwise the default disposition would
+        // terminate the whole test binary).
+        tokio::time::sleep(Duration::from_millis(300)).await;
+
+        let pid = std::process::id();
+        let status = std::process::Command::new("kill")
+            .arg("-TERM")
+            .arg(pid.to_string())
+            .status()
+            .expect("failed to invoke kill");
+        assert!(status.success(), "kill -TERM did not succeed");
+
+        // shutdown_signal should return promptly once SIGTERM is delivered.
+        tokio::time::timeout(Duration::from_secs(5), task)
+            .await
+            .expect("shutdown_signal did not return after SIGTERM")
+            .expect("shutdown_signal task panicked");
+    }
 }


### PR DESCRIPTION
Roadmap Priority #1 (T5). Fixes the SIGTERM gap the #146 audit surfaced — the only genuine bug in that audit.

## The bug
`shutdown_signal` listened for `ctrl_c` (SIGINT) only. Container runtimes — Docker, Kubernetes, Kong Mesh / Kuma sidecars — stop a process with **SIGTERM**, which hit the default disposition and **hard-killed** the process, dropping in-flight requests instead of draining them. (The old Completed roadmap claim said "SIGINT/SIGTERM" — it was false; corrected here.)

## The fix
Race `ctrl_c` with `tokio::signal::unix` `SignalKind::terminate()` via `tokio::select!`, log which signal fired, keep the 5s graceful drain. Canonical tokio/axum pattern.

- **Unix-gated:** non-Unix targets keep SIGINT-only (the SIGTERM branch is a never-ready `std::future::pending()`), so the `windows-latest` CI `cargo check` still compiles.
- Grace period pulled into a `SHUTDOWN_GRACE` const.

## Test
A `#[cfg(all(test, unix))]` unit test spawns `shutdown_signal`, waits for the handler to install, raises a real **SIGTERM** at the process (`kill -TERM $pid`), and asserts the future returns and initiates graceful shutdown — proving the process catches SIGTERM instead of dying. Verified the test binary survives (the handler intercepts the signal).

`cargo fmt --check` ✓ · `clippy --all-targets --all-features -D warnings` ✓ · `test --all-features` — 160 lib + 42 integration green.

## Docs
CHANGELOG, ROADMAP (T5 tick + Completed claim corrected + Priority Order refresh), README, INTERNALS §13 (code snippet + behavior prose).

🤖 Generated with [Claude Code](https://claude.com/claude-code)