### PR TITLE
fix: PID file configurable + non-fatal (read-only FS compat)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `request_id_enabled` config field (env: `RUCHO_REQUEST_ID_ENABLED`, default: on) and request-id middleware — sets an `X-Request-Id` header on every response for correlation with distributed tracing. Propagates a non-blank inbound `X-Request-Id` (Envoy / Kong Mesh (Kuma) sidecars set this header natively) unchanged, otherwise mints a UUID v4. Applied as the outermost layer so 404s, body-limit 413s, and CORS preflights are all covered; set only when a handler hasn't already set one, so `/response-headers?x-request-id=…` still wins. The request is never modified, so echo endpoints reflect exactly what the client sent.
 - `log_format` config field (env: `RUCHO_LOG_FORMAT`, default: `text`) — set to `json` for structured (`tracing_subscriber` JSON) log output suited to mesh/aggregator deployments (Loki, Datadog, ELK); `text` keeps the human-readable default. An unrecognized value warns and falls back to `text`.
+- `pid_file` config field (env: `RUCHO_PID_FILE`, default: `/var/run/rucho/rucho.pid`) — point the PID file at a writable location (e.g. `/tmp/rucho.pid`) for `--read-only` containers or non-root deployments.
 
 ### Changed
 - Chaos middleware now uses a per-thread cached RNG (`thread_local!` `StdRng`, seeded once from entropy) instead of constructing and re-seeding a `StdRng` from `thread_rng()` on every request. The v1.4.6 changelog described this optimization, but the implementation had continued to re-seed per request — this lands it for real. Internal only; chaos injection behavior is unchanged.
@@ -31,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `/redirect/:n` now emits an `X-Redirect-Count` response header (remaining hops) on each 302, so clients can observe chain progress without parsing the `Location` URL.
 
 ### Fixed
+- Server no longer refuses to start when the PID file can't be written (read-only filesystem, missing parent directory). `handle_start_command` now logs a warning and continues instead of returning failure and aborting startup — so `--read-only` containers run. The PID file only backs `rucho stop`/`status`; signal-based shutdown (SIGTERM / Ctrl+C) is unaffected.
 - `parse_cookies` now tolerates a missing space after the `;` separator (parses `a=1;b=2` as well as `a=1; b=2`), matching RFC 6265's lenient cookie parsing.
 - Metrics path normalization now bounds cardinality: unknown `/cookies/{action}` collapse to `/cookies/other`, and any unmatched path (404s, crawler/fuzzer noise) collapses to `/other`, instead of each becoming a permanent metric key. Also added the missing `/base64/:encoded` normalization, and `normalize_path` is now fully zero-allocation.
 - `/anything` handler no longer reads the full request body with `usize::MAX` limit — closes an OOM vector. `anything_handler` now uses the `Bytes` extractor which honors the configured `max_body_size_bytes`.

--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ Rucho loads configuration in this order (later overrides earlier):
 | `prefix`                    | `/usr/local/rucho`   | `RUCHO_PREFIX`                 | Installation prefix            |
 | `log_level`                 | `info`               | `RUCHO_LOG_LEVEL`              | Log level (trace/debug/info/warn/error) |
 | `log_format`                | `text`               | `RUCHO_LOG_FORMAT`            | Log output: `text` or `json` (structured) |
+| `pid_file`                  | `/var/run/rucho/rucho.pid` | `RUCHO_PID_FILE`         | PID file path (write is non-fatal) |
 | `server_listen_primary`     | `0.0.0.0:8080`       | `RUCHO_SERVER_LISTEN_PRIMARY`  | Primary HTTP listener          |
 | `server_listen_secondary`   | `0.0.0.0:9090`       | `RUCHO_SERVER_LISTEN_SECONDARY`| Secondary HTTP listener        |
 | `server_listen_tcp`         | (none)               | `RUCHO_SERVER_LISTEN_TCP`      | TCP echo listener address      |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -117,7 +117,7 @@ Docker/release ergonomics at **single-maintainer scope** — explicitly *not* pr
 - [x] **[H]** SIGTERM graceful-shutdown handler — `shutdown.rs` now races `ctrl_c` with `tokio::signal::unix` `SignalKind::terminate()`, so Docker/K8s/Kong-Mesh SIGTERM drains in-flight requests (5s grace) instead of hard-killing. Unix-gated; non-Unix keeps SIGINT-only (PR #148)
 - [x] **[M]** Request-ID middleware — sets `X-Request-Id` on every response (propagates a non-blank inbound id, else mints UUID v4; outermost layer; set-if-absent so handlers like `/response-headers` win). `request_id_enabled` toggle, default on (PR #147)
 - [x] **[M]** `log_format = json` config — `tracing_subscriber::fmt().json()` for structured-logging mesh deployments (Loki/Datadog/ELK); `text` default, unknown value warns and falls back (PR #149)
-- [ ] **[M]** Read-only-filesystem compatibility — PID path `/var/run/rucho` may break under `--read-only` Docker; make it tolerant/configurable (also the likely source of the stray `C:\var\run` artifact on Windows)
+- [x] **[M]** Read-only-filesystem compatibility — PID path is now configurable (`pid_file` / `RUCHO_PID_FILE`, default `/var/run/rucho/rucho.pid`) **and** a write failure is non-fatal: the server warns and starts anyway instead of aborting under `--read-only` Docker (PR #150)
 - [ ] **[M]** Auto-generated self-signed TLS certs (`ssl_auto_cert = true`, ephemeral in-memory via `rcgen`) — zero-setup HTTPS for dev/test; a test-ergonomics win, not gateway-redundant
 - [ ] **[L]** Alpine image variant (smaller image)
 - [ ] **[L]** Parallelize CI `deb` + `docker` jobs (both depend only on `build`)
@@ -151,11 +151,10 @@ Tell the dual-mission story and end the doc sprawl.
 
 Ranked by payoff for the dual mission:
 
-1. **Read-only-FS PID compat** — make the PID path configurable + non-fatal so `--read-only` containers start (the `log_format = json` half shipped in #149)
-2. **Echo HTTP version + TLS info in `/get`/`/anything`** — inspection fidelity beyond go-httpbin
-3. **`X-Response-Time` header from `RequestTiming`** — compare upstream- vs gateway-measured latency
+1. **Echo HTTP version + TLS info in `/get`/`/anything`** — inspection fidelity beyond go-httpbin
+2. **`X-Response-Time` header from `RequestTiming`** — compare upstream- vs gateway-measured latency
 
-_Done: `windows-latest` CI (#136) · "Why rucho?" + Kong docs (#137) · `spawn_full_app()` + lib refactor (#138) · multi-arch Docker (#139) · `/status` + `/redirect` (#140) · amd64-only PR CI (#141) · forced-encoding trio (#142) · metrics cardinality cap (#143) · `/cache` (#144) · cookie fidelity (#145) · ROADMAP reconcile (#146) · request-id middleware (#147) · SIGTERM shutdown (#148) · `log_format=json` (#149)._
+_Done: `windows-latest` CI (#136) · "Why rucho?" + Kong docs (#137) · `spawn_full_app()` + lib refactor (#138) · multi-arch Docker (#139) · `/status` + `/redirect` (#140) · amd64-only PR CI (#141) · forced-encoding trio (#142) · metrics cardinality cap (#143) · `/cache` (#144) · cookie fidelity (#145) · ROADMAP reconcile (#146) · request-id middleware (#147) · SIGTERM shutdown (#148) · `log_format=json` (#149) · read-only-FS PID compat (#150)._
 
 ---
 

--- a/config_samples/rucho.conf.default
+++ b/config_samples/rucho.conf.default
@@ -19,6 +19,12 @@ log_level = info
 # Example: log_format = json
 log_format = text
 
+# Path to the PID file backing `rucho stop`/`status`. A write failure here is
+# non-fatal — the server still starts (read-only filesystems, missing dir).
+# Point it at a writable location (e.g. /tmp/rucho.pid) under `--read-only`.
+# Example: pid_file = /tmp/rucho.pid
+pid_file = /var/run/rucho/rucho.pid
+
 # Primary server listen address and port.
 # Use 'ssl' suffix to enable TLS, e.g., 0.0.0.0:8043 ssl
 # Example: server_listen_primary = 127.0.0.1:8000

--- a/docs/INTERNALS.md
+++ b/docs/INTERNALS.md
@@ -198,8 +198,8 @@ main()                              src/main.rs
   +-- match args.command
         |
         CliCommand::Start =>
-          +-- handle_start_command()  src/cli/commands.rs
-          |     +-- write_pid_file(pid)
+          +-- handle_start_command(&config.pid_file)  src/cli/commands.rs
+          |     +-- write_pid_file(path, pid)  (non-fatal)
           |
           +-- Metrics::new() (if metrics_enabled)
           +-- build_app(metrics, compression_enabled, chaos, max_body_size_bytes, request_id_enabled)  src/app.rs
@@ -245,29 +245,30 @@ async fn main() {
     // Dispatch command
     match args.command {
         CliCommand::Start {} => {
-            if handle_start_command() {
-                let metrics = if config.metrics_enabled {
-                    tracing::info!("Metrics endpoint enabled at /metrics");
-                    Some(Arc::new(Metrics::new()))
-                } else {
-                    None
-                };
+            // PID-write failure is non-fatal; the server still starts.
+            handle_start_command(&config.pid_file);
 
-                // ... logging omitted for brevity ...
+            let metrics = if config.metrics_enabled {
+                tracing::info!("Metrics endpoint enabled at /metrics");
+                Some(Arc::new(Metrics::new()))
+            } else {
+                None
+            };
 
-                let chaos = Arc::new(config.chaos.clone());
-                let app = build_app(
-                    metrics,
-                    config.compression_enabled,
-                    chaos,
-                    config.max_body_size_bytes,
-                    config.request_id_enabled,
-                );
-                rucho::server::run_server(&config, app).await;
-            }
+            // ... logging omitted for brevity ...
+
+            let chaos = Arc::new(config.chaos.clone());
+            let app = build_app(
+                metrics,
+                config.compression_enabled,
+                chaos,
+                config.max_body_size_bytes,
+                config.request_id_enabled,
+            );
+            rucho::server::run_server(&config, app).await;
         }
-        CliCommand::Stop {} => handle_stop_command(),
-        CliCommand::Status {} => handle_status_command(),
+        CliCommand::Stop {} => handle_stop_command(&config.pid_file),
+        CliCommand::Status {} => handle_status_command(&config.pid_file),
         CliCommand::Version {} => handle_version_command(),
     }
 }
@@ -278,8 +279,9 @@ async fn main() {
 - `Config::load()` happens *before* tracing is initialized — errors from config
   loading go to `eprintln!` (stderr), not tracing.
 - `config.validate()` runs before anything else; exits with code 1 on failure.
-- The `build_app()` call happens *inside* the `Start` branch, after the PID file
-  is written.
+- The `build_app()` call happens *inside* the `Start` branch, after
+  `handle_start_command` (whose PID write is non-fatal — startup continues even
+  if the PID file can't be written).
 
 ---
 
@@ -1290,6 +1292,7 @@ pub struct Config {
     pub server_listen_udp: Option<String>, // e.g., "0.0.0.0:7778"
     pub ssl_cert: Option<String>,          // path to PEM cert
     pub ssl_key: Option<String>,           // path to PEM key
+    pub pid_file: String,                  // PID file path; write is non-fatal
     pub metrics_enabled: bool,
     pub compression_enabled: bool,
     pub request_id_enabled: bool,          // default true
@@ -1332,6 +1335,7 @@ pub struct ChaosConfig {
 | `server_listen_udp` | `Option<String>` | `None` | `server_listen_udp` | `RUCHO_SERVER_LISTEN_UDP` |
 | `ssl_cert` | `Option<String>` | `None` | `ssl_cert` | `RUCHO_SSL_CERT` |
 | `ssl_key` | `Option<String>` | `None` | `ssl_key` | `RUCHO_SSL_KEY` |
+| `pid_file` | `String` | `"/var/run/rucho/rucho.pid"` | `pid_file` | `RUCHO_PID_FILE` |
 | `metrics_enabled` | `bool` | `false` | `metrics_enabled` | `RUCHO_METRICS_ENABLED` |
 | `compression_enabled` | `bool` | `false` | `compression_enabled` | `RUCHO_COMPRESSION_ENABLED` |
 | `request_id_enabled` | `bool` | `true` | `request_id_enabled` | `RUCHO_REQUEST_ID_ENABLED` |
@@ -2082,23 +2086,28 @@ return `Json(snapshot)` directly.
 
 ### PID File Location
 
-The PID file path is hardcoded as a constant:
+The PID file path is configurable via the `pid_file` config field (env
+`RUCHO_PID_FILE`), defaulting to the `PID_FILE_PATH` constant:
 
 ```rust
-// src/utils/constants.rs
+// src/utils/constants.rs — the default
 pub const PID_FILE_PATH: &str = "/var/run/rucho/rucho.pid";
 ```
+
+Writing the PID file is **non-fatal**: if the path is unwritable (read-only
+filesystem, missing parent directory) the server logs a warning and starts
+anyway — point `pid_file` at a writable location (e.g. `/tmp`) under
+`--read-only`.
 
 ### Operations
 
 | Function | Description | Source |
 |----------|------------|--------|
-| `write_pid_file(pid)` | Creates file, writes PID + newline | `pid.rs` |
-| `read_pid_file()` | Reads file, parses as `usize` | `pid.rs` |
-| `remove_pid_file()` | Deletes the PID file | `pid.rs` |
+| `write_pid_file(path, pid)` | Creates file at `path`, writes PID + newline | `pid.rs` |
+| `read_pid_file(path)` | Reads file at `path`, parses as `usize` | `pid.rs` |
+| `remove_pid_file(path)` | Deletes the PID file at `path` | `pid.rs` |
 | `check_process_running(pid)` | Uses `sysinfo` to check if PID exists | `pid.rs` |
 | `stop_process(pid)` | Sends SIGTERM, waits 1s, checks if stopped | `pid.rs` |
-| `pid_file_path()` | Returns `PID_FILE_PATH` | `pid.rs` |
 
 ### Error Types
 
@@ -2154,11 +2163,10 @@ stop_process(pid)
 
 ### CLI Command Handlers
 
-**`handle_start_command()`** (`src/cli/commands.rs`):
+**`handle_start_command(pid_path)`** (`src/cli/commands.rs`):
 1. Gets current PID via `process::id()`.
-2. Writes PID file.
-3. Returns `true` on success (caller proceeds to start server), `false` on
-   failure (caller exits without starting).
+2. Writes the PID file at `pid_path`. A write failure is **non-fatal** — it
+   logs a warning; the caller starts the server regardless.
 
 **`handle_stop_command()`** (`src/cli/commands.rs`):
 1. Reads PID from file.

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -4,8 +4,8 @@ use clap::Parser;
 use std::process;
 
 use crate::utils::pid::{
-    check_process_running, pid_file_path, read_pid_file, remove_pid_file, stop_process,
-    write_pid_file, PidError, StopResult,
+    check_process_running, read_pid_file, remove_pid_file, stop_process, write_pid_file, PidError,
+    StopResult,
 };
 
 /// Represents the command line arguments passed to the application.
@@ -30,36 +30,35 @@ pub enum CliCommand {
     Version {},
 }
 
-/// Handles the start command by writing the PID file.
+/// Handles the start command by writing the PID file at `pid_path`.
 ///
-/// # Returns
-///
-/// `true` if the PID file was written successfully, `false` otherwise.
-pub fn handle_start_command() -> bool {
+/// A write failure (read-only filesystem, missing parent directory, …) is
+/// **non-fatal**: it logs a warning and the server still starts. The PID file
+/// only backs `rucho stop`/`status`; a containerized server is stopped with a
+/// signal (SIGTERM / Ctrl+C), so a missing PID file is acceptable there.
+pub fn handle_start_command(pid_path: &str) {
     println!("Starting server...");
     let pid = process::id();
 
-    match write_pid_file(pid) {
-        Ok(()) => {
-            println!("Server PID {} written to {}", pid, pid_file_path());
-            true
-        }
-        Err(e) => {
-            eprintln!("Error: {}", e);
-            false
-        }
+    match write_pid_file(pid_path, pid) {
+        Ok(()) => println!("Server PID {} written to {}", pid, pid_path),
+        Err(e) => eprintln!(
+            "Warning: could not write PID file at {}: {}. Starting anyway — \
+             stop the server with a signal (SIGTERM / Ctrl+C) rather than `rucho stop`.",
+            pid_path, e
+        ),
     }
 }
 
-/// Handles the stop command.
-pub fn handle_stop_command() {
-    match read_pid_file() {
+/// Handles the stop command, reading the PID from `pid_path`.
+pub fn handle_stop_command(pid_path: &str) {
+    match read_pid_file(pid_path) {
         Ok(pid_val) => {
             println!("Stopping server (PID: {})...", pid_val);
             match stop_process(pid_val) {
                 StopResult::Stopped => {
                     println!("Server stopped successfully.");
-                    if let Err(e) = remove_pid_file() {
+                    if let Err(e) = remove_pid_file(pid_path) {
                         eprintln!("Warning: {}", e);
                     }
                 }
@@ -78,7 +77,7 @@ pub fn handle_stop_command() {
                         "Process {} not found. It might have already stopped.",
                         pid_val
                     );
-                    if let Err(e) = remove_pid_file() {
+                    if let Err(e) = remove_pid_file(pid_path) {
                         eprintln!("Warning: {}", e);
                     }
                 }
@@ -92,10 +91,7 @@ pub fn handle_stop_command() {
         }
         Err(e) => {
             if matches!(e, PidError::ReadFailed(_)) {
-                println!(
-                    "Server not running (PID file {} not found).",
-                    pid_file_path()
-                );
+                println!("Server not running (PID file {} not found).", pid_path);
             } else {
                 eprintln!("Error: {}", e);
             }
@@ -103,30 +99,26 @@ pub fn handle_stop_command() {
     }
 }
 
-/// Handles the status command.
-pub fn handle_status_command() {
-    match read_pid_file() {
+/// Handles the status command, reading the PID from `pid_path`.
+pub fn handle_status_command(pid_path: &str) {
+    match read_pid_file(pid_path) {
         Ok(pid_val) => {
             if check_process_running(pid_val) {
                 println!("Server is running (PID: {}).", pid_val);
             } else {
                 println!(
                     "Server is stopped (PID file {} found, but process {} not running).",
-                    pid_file_path(),
-                    pid_val
+                    pid_path, pid_val
                 );
                 println!(
                     "Consider running 'rucho stop' to cleanup or manually delete {}.",
-                    pid_file_path()
+                    pid_path
                 );
             }
         }
         Err(e) => {
             if matches!(e, PidError::ReadFailed(_)) {
-                println!(
-                    "Server is stopped (PID file {} not found).",
-                    pid_file_path()
-                );
+                println!("Server is stopped (PID file {} not found).", pid_path);
             } else {
                 eprintln!("Error: {}", e);
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,41 +52,43 @@ async fn main() {
     // Dispatch command
     match args.command {
         CliCommand::Start {} => {
-            if handle_start_command() {
-                // Create metrics store if enabled
-                let metrics = if config.metrics_enabled {
-                    tracing::info!("Metrics endpoint enabled at /metrics");
-                    Some(Arc::new(Metrics::new()))
-                } else {
-                    None
-                };
+            // A PID-write failure is non-fatal (read-only FS, missing dir): the
+            // server still starts and can be stopped with a signal.
+            handle_start_command(&config.pid_file);
 
-                tracing::info!(
-                    "Connection settings: TCP keep-alive={}s, TCP nodelay={}, HTTP timeout={}s, header timeout={}s",
-                    config.tcp_keepalive_time,
-                    config.tcp_nodelay,
-                    config.http_keep_alive_timeout,
-                    config.header_read_timeout,
-                );
+            // Create metrics store if enabled
+            let metrics = if config.metrics_enabled {
+                tracing::info!("Metrics endpoint enabled at /metrics");
+                Some(Arc::new(Metrics::new()))
+            } else {
+                None
+            };
 
-                // Log chaos mode if enabled
-                if config.chaos.is_enabled() {
-                    tracing::info!("Chaos mode enabled: {}", config.chaos.modes.join(", "));
-                }
+            tracing::info!(
+                "Connection settings: TCP keep-alive={}s, TCP nodelay={}, HTTP timeout={}s, header timeout={}s",
+                config.tcp_keepalive_time,
+                config.tcp_nodelay,
+                config.http_keep_alive_timeout,
+                config.header_read_timeout,
+            );
 
-                let chaos = Arc::new(config.chaos.clone());
-                let app = build_app(
-                    metrics,
-                    config.compression_enabled,
-                    chaos,
-                    config.max_body_size_bytes,
-                    config.request_id_enabled,
-                );
-                rucho::server::run_server(&config, app).await;
+            // Log chaos mode if enabled
+            if config.chaos.is_enabled() {
+                tracing::info!("Chaos mode enabled: {}", config.chaos.modes.join(", "));
             }
+
+            let chaos = Arc::new(config.chaos.clone());
+            let app = build_app(
+                metrics,
+                config.compression_enabled,
+                chaos,
+                config.max_body_size_bytes,
+                config.request_id_enabled,
+            );
+            rucho::server::run_server(&config, app).await;
         }
-        CliCommand::Stop {} => handle_stop_command(),
-        CliCommand::Status {} => handle_status_command(),
+        CliCommand::Stop {} => handle_stop_command(&config.pid_file),
+        CliCommand::Status {} => handle_status_command(&config.pid_file),
         CliCommand::Version {} => handle_version_command(),
     }
 }

--- a/src/utils/config.rs
+++ b/src/utils/config.rs
@@ -6,7 +6,7 @@ use crate::utils::constants::{
     DEFAULT_HEADER_READ_TIMEOUT_SECS, DEFAULT_HTTP_KEEP_ALIVE_TIMEOUT_SECS, DEFAULT_LOG_FORMAT,
     DEFAULT_LOG_LEVEL, DEFAULT_MAX_BODY_SIZE_BYTES, DEFAULT_PREFIX, DEFAULT_SERVER_LISTEN_PRIMARY,
     DEFAULT_SERVER_LISTEN_SECONDARY, DEFAULT_TCP_KEEPALIVE_INTERVAL_SECS,
-    DEFAULT_TCP_KEEPALIVE_RETRIES, DEFAULT_TCP_KEEPALIVE_SECS,
+    DEFAULT_TCP_KEEPALIVE_RETRIES, DEFAULT_TCP_KEEPALIVE_SECS, PID_FILE_PATH,
 };
 
 /// Configuration for chaos engineering mode.
@@ -150,6 +150,10 @@ pub struct Config {
     pub ssl_cert: Option<String>,
     /// Optional path to an SSL private key file for HTTPS. Required if any listen address uses "ssl:".
     pub ssl_key: Option<String>,
+    /// Path to the PID file backing `rucho stop`/`status`. A write failure here
+    /// is non-fatal — the server still starts (read-only filesystems, missing
+    /// parent dir). Point it at a writable location (e.g. `/tmp`) if needed.
+    pub pid_file: String,
     /// Enable the /metrics endpoint for request statistics.
     pub metrics_enabled: bool,
     /// Enable response compression (gzip, brotli) based on client Accept-Encoding.
@@ -190,6 +194,7 @@ impl Default for Config {
             server_listen_udp: None,
             ssl_cert: None,
             ssl_key: None,
+            pid_file: PID_FILE_PATH.to_string(),
             metrics_enabled: false,
             compression_enabled: false,
             request_id_enabled: true,
@@ -265,6 +270,7 @@ impl Config {
                     "server_listen_udp" => config.server_listen_udp = Some(value.to_string()),
                     "ssl_cert" => config.ssl_cert = Some(value.to_string()),
                     "ssl_key" => config.ssl_key = Some(value.to_string()),
+                    "pid_file" => config.pid_file = value.to_string(),
                     "metrics_enabled" => {
                         config.metrics_enabled = value.eq_ignore_ascii_case("true") || value == "1"
                     }
@@ -439,6 +445,7 @@ impl Config {
         );
         load_env_var!(config, ssl_cert, "RUCHO_SSL_CERT", env_reader, option);
         load_env_var!(config, ssl_key, "RUCHO_SSL_KEY", env_reader, option);
+        load_env_var!(config, pid_file, "RUCHO_PID_FILE", env_reader);
         load_env_var!(
             config,
             metrics_enabled,
@@ -730,6 +737,7 @@ impl Config {
     /// - `server_listen_udp` (`RUCHO_SERVER_LISTEN_UDP`)
     /// - `ssl_cert` (`RUCHO_SSL_CERT`)
     /// - `ssl_key` (`RUCHO_SSL_KEY`)
+    /// - `pid_file` (`RUCHO_PID_FILE`)
     /// - `metrics_enabled` (`RUCHO_METRICS_ENABLED`)
     /// - `compression_enabled` (`RUCHO_COMPRESSION_ENABLED`)
     /// - `request_id_enabled` (`RUCHO_REQUEST_ID_ENABLED`)
@@ -1267,6 +1275,42 @@ mod tests {
         );
 
         assert_eq!(config.log_format, "json");
+    }
+
+    #[test]
+    fn test_pid_file_default() {
+        let config = Config::default();
+        assert_eq!(config.pid_file, PID_FILE_PATH);
+    }
+
+    #[test]
+    fn test_load_pid_file_from_file() {
+        let t = TestEnv::new();
+        t.create_config_file(&t.cwd_rucho_conf_path, "pid_file = /tmp/custom-rucho.pid");
+
+        let env = empty_env();
+        let config = Config::load_from_paths_with_env(
+            Some(t.non_existent_etc()),
+            Some(t.cwd_rucho_conf_path.clone()),
+            &env,
+        );
+
+        assert_eq!(config.pid_file, "/tmp/custom-rucho.pid");
+    }
+
+    #[test]
+    fn test_env_overrides_file_for_pid_file() {
+        let t = TestEnv::new();
+        t.create_config_file(&t.cwd_rucho_conf_path, "pid_file = /tmp/from-file.pid");
+
+        let env = mock_env(HashMap::from([("RUCHO_PID_FILE", "/tmp/from-env.pid")]));
+        let config = Config::load_from_paths_with_env(
+            Some(t.non_existent_etc()),
+            Some(t.cwd_rucho_conf_path.clone()),
+            &env,
+        );
+
+        assert_eq!(config.pid_file, "/tmp/from-env.pid");
     }
 
     // --- Chaos config tests ---

--- a/src/utils/pid.rs
+++ b/src/utils/pid.rs
@@ -8,8 +8,6 @@ use std::fs;
 use std::io::Write;
 use sysinfo::{Pid, Signal, System};
 
-use crate::utils::constants::PID_FILE_PATH;
-
 /// Errors that can occur during PID file operations.
 #[derive(Debug)]
 pub enum PidError {
@@ -45,42 +43,44 @@ impl std::fmt::Display for PidError {
 
 impl std::error::Error for PidError {}
 
-/// Writes the current process PID to the PID file.
+/// Writes the current process PID to the PID file at `path`.
 ///
 /// # Arguments
 ///
+/// * `path` - Filesystem path to write the PID file to
 /// * `pid` - The process ID to write
 ///
 /// # Returns
 ///
-/// `Ok(())` on success, or a `PidError` if the operation fails.
-pub fn write_pid_file(pid: u32) -> Result<(), PidError> {
-    let mut file = fs::File::create(PID_FILE_PATH).map_err(PidError::CreateFailed)?;
+/// `Ok(())` on success, or a `PidError` if the operation fails (e.g. the path
+/// is on a read-only filesystem or its parent directory does not exist).
+pub fn write_pid_file(path: &str, pid: u32) -> Result<(), PidError> {
+    let mut file = fs::File::create(path).map_err(PidError::CreateFailed)?;
     writeln!(file, "{}", pid).map_err(PidError::WriteFailed)?;
     Ok(())
 }
 
-/// Reads the PID from the PID file.
+/// Reads the PID from the PID file at `path`.
 ///
 /// # Returns
 ///
 /// `Ok(pid)` if successful, or `Err(PidError)` if the file doesn't exist,
 /// can't be read, or contains an invalid format.
-pub fn read_pid_file() -> Result<usize, PidError> {
-    let contents = fs::read_to_string(PID_FILE_PATH).map_err(PidError::ReadFailed)?;
+pub fn read_pid_file(path: &str) -> Result<usize, PidError> {
+    let contents = fs::read_to_string(path).map_err(PidError::ReadFailed)?;
     contents
         .trim()
         .parse::<usize>()
         .map_err(|_| PidError::InvalidFormat)
 }
 
-/// Removes the PID file.
+/// Removes the PID file at `path`.
 ///
 /// # Returns
 ///
 /// `Ok(())` on success, or a `PidError` if removal fails.
-pub fn remove_pid_file() -> Result<(), PidError> {
-    fs::remove_file(PID_FILE_PATH).map_err(PidError::RemoveFailed)
+pub fn remove_pid_file(path: &str) -> Result<(), PidError> {
+    fs::remove_file(path).map_err(PidError::RemoveFailed)
 }
 
 /// Checks if a process with the given PID is running.
@@ -151,7 +151,51 @@ pub fn stop_process(pid_val: usize) -> StopResult {
     }
 }
 
-/// Returns the path to the PID file.
-pub fn pid_file_path() -> &'static str {
-    PID_FILE_PATH
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::process;
+    use tempfile::TempDir;
+
+    #[test]
+    fn write_then_read_roundtrips() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("rucho.pid");
+        let path = path.to_str().unwrap();
+
+        write_pid_file(path, 4242).expect("write should succeed in a writable dir");
+        assert_eq!(read_pid_file(path).unwrap(), 4242);
+
+        remove_pid_file(path).expect("remove should succeed");
+        assert!(read_pid_file(path).is_err(), "file should be gone");
+    }
+
+    #[test]
+    fn read_missing_file_errors() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("absent.pid");
+        assert!(matches!(
+            read_pid_file(path.to_str().unwrap()),
+            Err(PidError::ReadFailed(_))
+        ));
+    }
+
+    #[test]
+    fn read_invalid_contents_errors() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("bad.pid");
+        std::fs::write(&path, "not-a-pid").unwrap();
+        assert!(matches!(
+            read_pid_file(path.to_str().unwrap()),
+            Err(PidError::InvalidFormat)
+        ));
+    }
+
+    #[test]
+    fn write_to_unwritable_path_errors_without_panicking() {
+        // Parent directory does not exist (stands in for a read-only FS): the
+        // function must return an error, not panic — callers stay tolerant.
+        let result = write_pid_file("/nonexistent-rucho-dir/sub/rucho.pid", process::id());
+        assert!(matches!(result, Err(PidError::CreateFailed(_))));
+    }
 }


### PR DESCRIPTION
Second half of the split roadmap T5 item (`log_format` shipped in #149). Fixes a real startup bug and adds the `pid_file` config field.

## The bug
Under `--read-only` Docker (or any time `/var/run/rucho/` isn't writable), `write_pid_file` failed → `handle_start_command` returned `false` → **the server never started**. I hit this exact failure while smoke-testing #149.

## The fix
- **`pid_file` config field** (env `RUCHO_PID_FILE`, default `/var/run/rucho/rucho.pid`) — point it at a writable location (e.g. `/tmp/rucho.pid`).
- **Non-fatal write** — a PID-write failure now logs a warning and the server starts anyway. The PID file only backs `rucho stop`/`status`; containers stop via SIGTERM (handled since #148), so a missing PID file is fine there.

Refactor: `pid.rs` functions take the path as a parameter (which also makes them **unit-testable for the first time**); `pid_file_path()` removed; the three command handlers and `main()` thread `&config.pid_file` through; `handle_start_command` no longer returns a bool gate.

## Tests
- **4 `pid` unit tests**: write→read roundtrip, missing-file error, invalid-contents error, and unwritable-path-errors-**without-panicking** (the tolerance guarantee).
- **3 config tests**: `pid_file` default / from-file / env-overrides-file.

## Verified live (end-to-end)
With the path now configurable I could finally run the server in my sandbox — confirming this PR **and** retroactively #148 + #149:
- **Writable PID** (`/tmp`): `Server PID … written to /tmp/rucho-test.pid`, JSON logs emitted, SIGTERM → graceful drain.
- **Unwritable PID** (`/var/run/rucho`): `Warning: could not write PID file … Starting anyway` → **server starts** (`2 server(s)/listener(s) started`) → SIGTERM → graceful drain. This is the bug fix, demonstrated.

`cargo fmt --check` ✓ · `clippy --all-targets --all-features -D warnings` ✓ · `test --all-features` — 170 lib + 42 integration green.

## Docs
CHANGELOG (Added `pid_file` + Fixed non-fatal startup), ROADMAP (T5 tick + Priority Order refresh), README (config table), INTERNALS (PID-management section, `main()` snippet, config struct + table, flow diagram), `config_samples`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)