### PR TITLE
docs: Consistency sweep — sync all docs with code

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,13 +150,14 @@ Rucho loads configuration in this order (later overrides earlier):
 | `ssl_key`                   | (none)               | `RUCHO_SSL_KEY`                | Path to SSL private key        |
 | `metrics_enabled`           | `false`              | `RUCHO_METRICS_ENABLED`        | Enable /metrics endpoint       |
 | `compression_enabled`       | `false`              | `RUCHO_COMPRESSION_ENABLED`    | Enable gzip/brotli compression |
-| `request_id_enabled`        | `true`               | `RUCHO_REQUEST_ID_ENABLED`     | X-Request-Id header on responses |
+| `request_id_enabled`        | `true`               | `RUCHO_REQUEST_ID_ENABLED`     | X-Request-Id correlation header (propagates inbound, else mints UUID v4) |
 | `http_keep_alive_timeout`   | `75`                 | `RUCHO_HTTP_KEEP_ALIVE_TIMEOUT`| HTTP idle connection timeout (seconds) |
 | `tcp_keepalive_time`        | `60`                 | `RUCHO_TCP_KEEPALIVE_TIME`     | TCP keepalive idle time (seconds) |
 | `tcp_keepalive_interval`    | `15`                 | `RUCHO_TCP_KEEPALIVE_INTERVAL` | TCP keepalive probe interval (seconds) |
 | `tcp_keepalive_retries`     | `5`                  | `RUCHO_TCP_KEEPALIVE_RETRIES`  | TCP keepalive probe retries (1-10) |
 | `tcp_nodelay`               | `true`               | `RUCHO_TCP_NODELAY`            | Disable Nagle's algorithm |
 | `header_read_timeout`       | `30`                 | `RUCHO_HEADER_READ_TIMEOUT`    | Max time to read request headers (seconds) |
+| `max_body_size_bytes`       | `2097152` (2 MiB)    | `RUCHO_MAX_BODY_SIZE_BYTES`    | Max request body size in bytes (global limit; 413 if exceeded) |
 | `chaos_mode`                | (none)               | `RUCHO_CHAOS_MODE`             | Enable [chaos types](#chaos-engineering-mode) |
 
 ### HTTPS Configuration

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -154,7 +154,7 @@ Ranked by payoff for the dual mission:
 
 1. **Echo TLS info in `/get`/`/anything`** — bigger lift: needs the HTTPS accept loop reworked to surface rustls connection params (see T1). The high-value, low-cost Priority Order items are now shipped; remaining work is this TLS rework plus the T4 (testing) / T6 (documentation) tiers
 
-_Done: `windows-latest` CI (#136) · "Why rucho?" + Kong docs (#137) · `spawn_full_app()` + lib refactor (#138) · multi-arch Docker (#139) · `/status` + `/redirect` (#140) · amd64-only PR CI (#141) · forced-encoding trio (#142) · metrics cardinality cap (#143) · `/cache` (#144) · cookie fidelity (#145) · ROADMAP reconcile (#146) · request-id middleware (#147) · SIGTERM shutdown (#148) · `log_format=json` (#149) · read-only-FS PID compat (#150) · `http_version` echo (#151) · `X-Response-Time` header (#152)._
+_Done: `windows-latest` CI (#136) · "Why rucho?" + Kong docs (#137) · `spawn_full_app()` + lib refactor (#138) · multi-arch Docker (#139) · `/status` + `/redirect` (#140) · amd64-only PR CI (#141) · forced-encoding trio (#142) · metrics cardinality cap (#143) · `/cache` (#144) · cookie fidelity (#145) · ROADMAP reconcile (#146) · request-id middleware (#147) · SIGTERM shutdown (#148) · `log_format=json` (#149) · read-only-FS PID compat (#150) · `http_version` echo (#151) · `X-Response-Time` header (#152) · MSRV alignment (#153)._
 
 ---
 

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -23,7 +23,7 @@ Complete reference for all Rucho HTTP endpoints.
 
 ## Echo Endpoints
 
-Core echo handlers that reflect request details back to the caller. All echo responses include a `timing` object with processing duration.
+Core echo handlers that reflect request details back to the caller. All echo responses include an `http_version` field and a `timing` object with processing duration.
 
 ### GET /get
 
@@ -78,6 +78,7 @@ Echo request details including the parsed JSON body.
 ```json
 {
   "method": "POST",
+  "http_version": "HTTP/1.1",
   "headers": { "content-type": "application/json", "..." : "..." },
   "body": { "key": "value" },
   "timing": {
@@ -117,6 +118,7 @@ Echo request details. Body is optional — if a JSON body is sent it is echoed; 
 | Field | Type | Description |
 |-------|------|-------------|
 | `method` | string | `"DELETE"` |
+| `http_version` | string | HTTP version (e.g. `"HTTP/1.1"`, `"HTTP/2.0"`) |
 | `headers` | object | All request headers |
 | `body` | any \| null | Parsed JSON body, or `null` if none sent |
 | `timing.duration_ms` | number | Processing time in milliseconds |
@@ -294,6 +296,7 @@ Echo any request regardless of HTTP method. Returns method, path, query string, 
 ```json
 {
   "method": "PUT",
+  "http_version": "HTTP/1.1",
   "path": "/anything",
   "query": "foo=bar",
   "headers": { "..." : "..." },
@@ -627,6 +630,15 @@ curl -i http://localhost:8080/cache/60
 ---
 
 ## Infrastructure
+
+### Response Headers
+
+Set on every response by the middleware stack:
+
+| Header | Description |
+|--------|-------------|
+| `X-Request-Id` | Correlation ID. Propagates a non-blank inbound `X-Request-Id`, otherwise mints a UUID v4. Toggle with `request_id_enabled` (default on). |
+| `X-Response-Time` | Upstream processing time, e.g. `1.234ms` — the same value as the body's `timing.duration_ms`. |
 
 ### GET /healthz
 

--- a/docs/INTERNALS.md
+++ b/docs/INTERNALS.md
@@ -1369,6 +1369,7 @@ pub struct ChaosConfig {
 | `tcp_keepalive_retries` | `u32` | `5` | `tcp_keepalive_retries` | `RUCHO_TCP_KEEPALIVE_RETRIES` |
 | `tcp_nodelay` | `bool` | `true` | `tcp_nodelay` | `RUCHO_TCP_NODELAY` |
 | `header_read_timeout` | `u64` | `30` | `header_read_timeout` | `RUCHO_HEADER_READ_TIMEOUT` |
+| `max_body_size_bytes` | `usize` | `2097152` | `max_body_size_bytes` | `RUCHO_MAX_BODY_SIZE_BYTES` |
 | `chaos.modes` | `Vec<String>` | `[]` | `chaos_mode` | `RUCHO_CHAOS_MODE` |
 | `chaos.failure_rate` | `f64` | `0.0` | `chaos_failure_rate` | `RUCHO_CHAOS_FAILURE_RATE` |
 | `chaos.failure_codes` | `Vec<u16>` | `[]` | `chaos_failure_codes` | `RUCHO_CHAOS_FAILURE_CODES` |

--- a/docs/USAGE_EXAMPLES.md
+++ b/docs/USAGE_EXAMPLES.md
@@ -124,6 +124,7 @@ console.log(data);
 ```json
 {
   "method": "POST",
+  "http_version": "HTTP/1.1",
   "headers": {
     "host": "localhost:8080",
     "content-type": "application/json",
@@ -442,6 +443,7 @@ console.log(data);
 ```json
 {
   "method": "POST",
+  "http_version": "HTTP/1.1",
   "path": "/anything/my/custom/path",
   "query": "debug=true&level=5",
   "headers": {

--- a/src/utils/config.rs
+++ b/src/utils/config.rs
@@ -741,6 +741,14 @@ impl Config {
     /// - `metrics_enabled` (`RUCHO_METRICS_ENABLED`)
     /// - `compression_enabled` (`RUCHO_COMPRESSION_ENABLED`)
     /// - `request_id_enabled` (`RUCHO_REQUEST_ID_ENABLED`)
+    /// - `http_keep_alive_timeout` (`RUCHO_HTTP_KEEP_ALIVE_TIMEOUT`)
+    /// - `tcp_keepalive_time` (`RUCHO_TCP_KEEPALIVE_TIME`)
+    /// - `tcp_keepalive_interval` (`RUCHO_TCP_KEEPALIVE_INTERVAL`)
+    /// - `tcp_keepalive_retries` (`RUCHO_TCP_KEEPALIVE_RETRIES`)
+    /// - `tcp_nodelay` (`RUCHO_TCP_NODELAY`)
+    /// - `header_read_timeout` (`RUCHO_HEADER_READ_TIMEOUT`)
+    /// - `max_body_size_bytes` (`RUCHO_MAX_BODY_SIZE_BYTES`)
+    /// - chaos keys (`RUCHO_CHAOS_*`) — see `config_samples/rucho.conf.default`
     pub fn load() -> Self {
         Self::load_from_paths(None, None)
     }


### PR DESCRIPTION
Final wrap-up: a full docs/markdown consistency sweep after this session's eight PRs (#146–#153). A 6-agent audit cross-checked every doc (README, INTERNALS, API_REFERENCE, USAGE_EXAMPLES, CHANGELOG, ROADMAP, CONTRIBUTING, config sample) against the actual source, plus a dedicated config-field cross-check. Real gaps found and fixed:

## Pre-existing gap the audit caught
- **`max_body_size_bytes`** (shipped back in #109) was never added to the config-options tables. Added to the **README** table, **INTERNALS §7.2** field reference, and the **`Config::load` supported-keys doc-comment** — which was itself missing all the connection-tuning keys (`http_keep_alive_timeout`, `tcp_*`, `header_read_timeout`, `max_body_size_bytes`), now listed.

## This session's fields/headers, now fully documented
- **`http_version`** (#151) was only shown in the `/get` examples — added to the **POST**, **DELETE**, and **/anything** examples in `API_REFERENCE.md` and `USAGE_EXAMPLES.md`, plus the API_REFERENCE echo-section intro.
- New **`Response Headers`** subsection in `API_REFERENCE.md` documenting **`X-Request-Id`** (#147) and **`X-Response-Time`** (#152), which were emitted on every response but undocumented.
- **ROADMAP** "Done" line was missing **MSRV alignment (#153)** — added.
- Sharpened the README `request_id_enabled` description (propagate-else-mint).

## Deliberately skipped
- A README `log_format` backtick "nit" (the suggested change wasn't an improvement).
- Uncommenting `max_body_size_bytes` in `config_samples` — it's intentionally a commented example like its tuning-block siblings.

Docs / doc-comment only. `cargo fmt --check` ✓ · `clippy --all-targets --all-features -D warnings` ✓ · `test --all-features` — 172 lib + 46 integration green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)