### PR TITLE
test: Fill integration-test coverage gaps (T4)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -103,7 +103,7 @@ Coverage that backs the "more robust than httpbin" claim, and CI that catches th
 
 - [x] **[H]** Add `windows-latest` to the CI matrix for `cargo check` — catches platform-gated drift; Rucho confirmed to compile cleanly on Windows (PR #136)
 - [x] **[H]** `spawn_full_app()` test helper using the real `build_app()` — exposed `build_app`→`src/app.rs` and `ApiDoc`→`src/openapi.rs` in the library; 3 full-stack regression tests incl. one proving the metrics middleware records requests (PR #138)
-- [ ] **[M]** Integration-test gaps — `/delay` fires (≥1 s), `HEAD /get`, response compression, `/endpoints` shape, malformed-JSON → 400. (`/metrics` enabled is already covered by the `spawn_full_app` tests; `/status/:code` only partially — just 418 is asserted.)
+- [x] **[M]** Integration-test gaps — added `/delay` fires (≥1 s) + over-cap 400, `HEAD /get` empty body, response compression (gzip via a compression-enabled app), `/endpoints` shape, malformed-JSON → 400, and fuller `/status/:code` reason-phrase coverage (404/500/200, not just 418) (PR #156)
 - [ ] **[M]** Property tests — chaos probabilities stay within bounds; `/redirect/:n` yields exactly `n` hops; `parse_cookies` never panics on any byte sequence
 - [ ] **[M]** Benchmark gaps — `/anything` with a body, cookies roundtrip, metrics-contention concurrency, full middleware stack vs bare handler; benchmark `/redirect`
 - [ ] **[L]** MSRV CI job pinning `rust-version` from `Cargo.toml` (the CONTRIBUTING-vs-Dockerfile mismatch was resolved in #153 and `rust-version = "1.84"` is now declared; a dedicated CI job that builds on exactly 1.84 is the remaining piece)

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -943,3 +943,158 @@ async fn test_get_omits_tls_info_over_plain_http() {
         "plain HTTP must omit tls, got: {body}"
     );
 }
+
+// --- Coverage-gap tests (T4) ---
+
+/// Like `spawn_full_app` but with response compression enabled, for exercising
+/// the `CompressionLayer` (which `Config::default()` leaves off).
+async fn spawn_app_with_compression() -> String {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    let config = rucho::utils::config::Config::default();
+    let metrics = Some(std::sync::Arc::new(rucho::utils::metrics::Metrics::new()));
+    let chaos = std::sync::Arc::new(config.chaos.clone());
+    let app = rucho::app::build_app(
+        metrics,
+        true, // compression_enabled
+        chaos,
+        config.max_body_size_bytes,
+        config.request_id_enabled,
+    );
+
+    tokio::spawn(async move {
+        axum::serve(
+            listener,
+            app.into_make_service_with_connect_info::<std::net::SocketAddr>(),
+        )
+        .await
+        .unwrap()
+    });
+
+    format!("http://{addr}")
+}
+
+#[tokio::test]
+async fn test_delay_fires() {
+    let base = spawn_app().await;
+    let start = std::time::Instant::now();
+    let resp = reqwest::get(format!("{base}/delay/1")).await.unwrap();
+
+    assert_eq!(resp.status(), 200);
+    assert!(
+        start.elapsed() >= std::time::Duration::from_secs(1),
+        "/delay/1 should block for at least one second"
+    );
+    assert_eq!(resp.text().await.unwrap(), "Response delayed by 1 seconds");
+}
+
+#[tokio::test]
+async fn test_delay_exceeds_max_returns_400() {
+    let base = spawn_app().await;
+    let resp = reqwest::get(format!("{base}/delay/301")).await.unwrap();
+    assert_eq!(resp.status(), 400);
+}
+
+#[tokio::test]
+async fn test_head_get_returns_no_body() {
+    let base = spawn_app().await;
+    let resp = reqwest::Client::new()
+        .head(format!("{base}/get"))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), 200);
+    assert!(
+        resp.bytes().await.unwrap().is_empty(),
+        "HEAD /get must return an empty body"
+    );
+}
+
+#[tokio::test]
+async fn test_endpoints_shape() {
+    let base = spawn_app().await;
+    let resp = reqwest::get(format!("{base}/endpoints")).await.unwrap();
+
+    assert_eq!(resp.status(), 200);
+    let body: serde_json::Value = resp.json().await.unwrap();
+    let endpoints = body["endpoints"]
+        .as_array()
+        .expect("`endpoints` should be an array");
+    assert!(!endpoints.is_empty());
+    for e in endpoints {
+        assert!(e["path"].is_string(), "each entry needs a path: {e}");
+        assert!(e["method"].is_string(), "each entry needs a method: {e}");
+        assert!(
+            e["description"].is_string(),
+            "each entry needs a description: {e}"
+        );
+    }
+    assert!(
+        endpoints.iter().any(|e| e["path"] == "/get"),
+        "/get should be listed in /endpoints"
+    );
+}
+
+#[tokio::test]
+async fn test_post_malformed_json_returns_400() {
+    let base = spawn_app().await;
+    let resp = reqwest::Client::new()
+        .post(format!("{base}/post"))
+        .header(reqwest::header::CONTENT_TYPE, "application/json")
+        .body("{not valid json")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 400);
+}
+
+#[tokio::test]
+async fn test_status_code_carries_reason_phrase() {
+    let base = spawn_app().await;
+    // Beyond the 418 case already covered: assert the canonical reason phrase
+    // travels in the body while the status line carries the requested code.
+    for (code, reason) in [
+        (404u16, "Not Found"),
+        (500, "Internal Server Error"),
+        (200, "OK"),
+    ] {
+        let resp = reqwest::get(format!("{base}/status/{code}")).await.unwrap();
+        assert_eq!(resp.status(), code);
+        let body: serde_json::Value = resp.json().await.unwrap();
+        assert_eq!(body["status"], code);
+        assert_eq!(body["reason"], reason);
+    }
+}
+
+#[tokio::test]
+async fn test_response_compression_gzip() {
+    use std::io::Read;
+    let base = spawn_app_with_compression().await;
+
+    let resp = reqwest::Client::new()
+        .get(format!("{base}/get"))
+        .header(reqwest::header::ACCEPT_ENCODING, "gzip")
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), 200);
+    assert_eq!(
+        resp.headers()
+            .get(reqwest::header::CONTENT_ENCODING)
+            .map(|v| v.to_str().unwrap()),
+        Some("gzip"),
+        "CompressionLayer should gzip /get when Accept-Encoding: gzip and compression is enabled"
+    );
+
+    // The test reqwest client has no gzip feature, so decompress the raw bytes.
+    let raw = resp.bytes().await.unwrap();
+    let mut s = String::new();
+    flate2::read::GzDecoder::new(&raw[..])
+        .read_to_string(&mut s)
+        .unwrap();
+    let body: serde_json::Value = serde_json::from_str(&s).unwrap();
+    assert_eq!(body["method"], "GET");
+}


### PR DESCRIPTION
## What

Adds reqwest integration tests for behaviors that previously lacked coverage — the T4 "integration-test gaps" roadmap item. **Test-only; no production code touched.**

| Test | Covers |
|------|--------|
| `test_delay_fires` | `/delay/1` actually blocks ≥ 1s and returns `"Response delayed by 1 seconds"` |
| `test_delay_exceeds_max_returns_400` | `/delay/301` (over the 300s cap) → 400 |
| `test_head_get_returns_no_body` | `HEAD /get` → 200 with an empty body |
| `test_endpoints_shape` | `/endpoints` → `{"endpoints": [{path, method, description}, …]}`, and lists `/get` |
| `test_post_malformed_json_returns_400` | `POST /post` with malformed JSON → 400 |
| `test_status_code_carries_reason_phrase` | `/status/{404,500,200}` carry the canonical reason phrase in the body (prior test only asserted 418) |
| `test_response_compression_gzip` | the `CompressionLayer` gzips `/get` when `Accept-Encoding: gzip` |

## Notes

- **Compression** needed a dedicated `spawn_app_with_compression()` helper: `Config::default()` leaves `compression_enabled` **off**, so `spawn_full_app` can't exercise the layer. The new helper builds the real `build_app()` with compression on. Since the test reqwest client has no `gzip` feature, it receives the raw gzip bytes (so `Content-Encoding: gzip` is observable) and decompresses them with `flate2` — mirroring the existing `/gzip` endpoint test.
- `/metrics`-enabled and the full-stack echo are already covered by the existing `spawn_full_app` tests, so they're not duplicated here.

Full suite green: **174 lib + 56 integration** (+7 new) · `cargo fmt` + `clippy --all-targets --all-features -D warnings` clean.

Ticks the T4 integration-test-gaps item in ROADMAP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)