### PR TITLE
test: Add benchmark coverage for the missing hot paths (T4)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -105,7 +105,7 @@ Coverage that backs the "more robust than httpbin" claim, and CI that catches th
 - [x] **[H]** `spawn_full_app()` test helper using the real `build_app()` — exposed `build_app`→`src/app.rs` and `ApiDoc`→`src/openapi.rs` in the library; 3 full-stack regression tests incl. one proving the metrics middleware records requests (PR #138)
 - [x] **[M]** Integration-test gaps — added `/delay` fires (≥1 s) + over-cap 400, `HEAD /get` empty body, response compression (gzip via a compression-enabled app), `/endpoints` shape, malformed-JSON → 400, and fuller `/status/:code` reason-phrase coverage (404/500/200, not just 418) (PR #156)
 - [x] **[M]** Property tests (`proptest`) — chaos roll stays in `[0,1)` and a `0.0` rate never fires; `/redirect/:n` points exactly one hop closer for all in-range `n` (so the chain is exactly `n` hops); `parse_cookies` never panics and never yields an empty cookie name (PR #157)
-- [ ] **[M]** Benchmark gaps — `/anything` with a body, cookies roundtrip, metrics-contention concurrency, full middleware stack vs bare handler; benchmark `/redirect`
+- [x] **[M]** Benchmark gaps — added `POST /anything` (with body), cookies set+read roundtrip, `GET /redirect/3`, `GET /get` through the full middleware stack (vs the bare handler, to quantify overhead), and a 4-task concurrent `Metrics::record_request` contention bench (the baseline a DashMap/sharded swap would beat) (PR #158)
 - [ ] **[L]** MSRV CI job pinning `rust-version` from `Cargo.toml` (the CONTRIBUTING-vs-Dockerfile mismatch was resolved in #153 and `rust-version = "1.84"` is now declared; a dedicated CI job that builds on exactly 1.84 is the remaining piece)
 
 ---

--- a/benches/endpoint_benchmarks.rs
+++ b/benches/endpoint_benchmarks.rs
@@ -2,20 +2,38 @@ use criterion::{criterion_group, criterion_main, Criterion};
 
 use axum::{body::Body, middleware, Router};
 use http::Request;
-use rucho::routes::{core_routes, delay, healthz};
+use rucho::routes::{cookies, core_routes, delay, healthz, redirect};
 use rucho::server::timing_layer::timing_middleware;
+use std::sync::Arc;
 use tower::ServiceExt;
 
 /// Builds a minimal app router for benchmarking.
 ///
-/// Includes the core routes, healthz, and delay with timing middleware —
-/// no chaos, metrics, tracing, or compression to isolate handler performance.
+/// Includes the core routes, healthz, delay, redirect, and cookies with timing
+/// middleware — no chaos, metrics, tracing, or compression to isolate handler
+/// performance.
 fn bench_app() -> Router {
     Router::new()
         .merge(core_routes::router())
         .merge(healthz::router())
         .merge(delay::router())
+        .merge(redirect::router())
+        .merge(cookies::router())
         .layer(middleware::from_fn(timing_middleware))
+}
+
+/// Builds the full application router exactly as the binary wires it (metrics,
+/// chaos-gate, timing, trace, compression toggle, CORS, normalize-path,
+/// request-id), for the bare-vs-full-stack comparison.
+fn bench_full_app() -> Router {
+    let config = rucho::utils::config::Config::default();
+    rucho::app::build_app(
+        Some(Arc::new(rucho::utils::metrics::Metrics::new())),
+        config.compression_enabled,
+        Arc::new(config.chaos.clone()),
+        config.max_body_size_bytes,
+        config.request_id_enabled,
+    )
 }
 
 fn bench_get_healthz(c: &mut Criterion) {
@@ -124,6 +142,134 @@ fn bench_get_endpoints(c: &mut Criterion) {
     });
 }
 
+fn bench_post_anything_with_body(c: &mut Criterion) {
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    let app = bench_app();
+    let body = r#"{"name":"rucho","values":[1,2,3,4,5],"nested":{"a":true,"b":"text"}}"#;
+
+    c.bench_function("POST /anything (with body)", |b| {
+        b.to_async(&rt).iter(|| {
+            let app = app.clone();
+            async move {
+                let req = Request::builder()
+                    .method("POST")
+                    .uri("/anything")
+                    .header("content-type", "application/json")
+                    .body(Body::from(body))
+                    .unwrap();
+                let resp = app.oneshot(req).await.unwrap();
+                axum::body::to_bytes(resp.into_body(), usize::MAX)
+                    .await
+                    .unwrap();
+            }
+        });
+    });
+}
+
+fn bench_cookies_roundtrip(c: &mut Criterion) {
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    let app = bench_app();
+
+    c.bench_function("cookies roundtrip (set + read)", |b| {
+        b.to_async(&rt).iter(|| {
+            let app = app.clone();
+            async move {
+                // Set path: emits Set-Cookie headers + redirect.
+                let set = Request::builder()
+                    .uri("/cookies/set?session=abc123&theme=dark")
+                    .body(Body::empty())
+                    .unwrap();
+                let r1 = app.clone().oneshot(set).await.unwrap();
+                axum::body::to_bytes(r1.into_body(), usize::MAX)
+                    .await
+                    .unwrap();
+
+                // Read path: parses the Cookie header back into JSON.
+                let read = Request::builder()
+                    .uri("/cookies")
+                    .header("cookie", "session=abc123; theme=dark")
+                    .body(Body::empty())
+                    .unwrap();
+                let r2 = app.oneshot(read).await.unwrap();
+                axum::body::to_bytes(r2.into_body(), usize::MAX)
+                    .await
+                    .unwrap();
+            }
+        });
+    });
+}
+
+fn bench_get_redirect(c: &mut Criterion) {
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    let app = bench_app();
+
+    c.bench_function("GET /redirect/3", |b| {
+        b.to_async(&rt).iter(|| {
+            let app = app.clone();
+            async move {
+                let req = Request::builder()
+                    .uri("/redirect/3")
+                    .body(Body::empty())
+                    .unwrap();
+                let resp = app.oneshot(req).await.unwrap();
+                axum::body::to_bytes(resp.into_body(), usize::MAX)
+                    .await
+                    .unwrap();
+            }
+        });
+    });
+}
+
+/// Compare a `GET /get` through the full middleware stack against the bare
+/// handler (`bench_get_get`) to quantify the middleware overhead.
+fn bench_get_get_full_stack(c: &mut Criterion) {
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    let app = bench_full_app();
+
+    c.bench_function("GET /get (full middleware stack)", |b| {
+        b.to_async(&rt).iter(|| {
+            let app = app.clone();
+            async move {
+                let req = Request::builder().uri("/get").body(Body::empty()).unwrap();
+                let resp = app.oneshot(req).await.unwrap();
+                axum::body::to_bytes(resp.into_body(), usize::MAX)
+                    .await
+                    .unwrap();
+            }
+        });
+    });
+}
+
+/// Concurrent `record_request` to surface lock contention on the metrics map
+/// (`RwLock<HashMap>`) — the baseline a future DashMap/sharded swap would beat.
+fn bench_metrics_contention(c: &mut Criterion) {
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(4)
+        .build()
+        .unwrap();
+    let metrics = Arc::new(rucho::utils::metrics::Metrics::new());
+
+    c.bench_function("Metrics::record_request (4 tasks x 100)", |b| {
+        b.to_async(&rt).iter(|| {
+            let metrics = metrics.clone();
+            async move {
+                let mut handles = Vec::with_capacity(4);
+                for _ in 0..4 {
+                    let m = metrics.clone();
+                    handles.push(tokio::spawn(async move {
+                        for _ in 0..100 {
+                            m.record_request("/get", 200);
+                        }
+                    }));
+                }
+                for h in handles {
+                    h.await.unwrap();
+                }
+            }
+        });
+    });
+}
+
 criterion_group!(
     benches,
     bench_get_healthz,
@@ -131,5 +277,10 @@ criterion_group!(
     bench_get_uuid,
     bench_post_post,
     bench_get_endpoints,
+    bench_post_anything_with_body,
+    bench_cookies_roundtrip,
+    bench_get_redirect,
+    bench_get_get_full_stack,
+    bench_metrics_contention,
 );
 criterion_main!(benches);


### PR DESCRIPTION
## What

Fills the T4 "benchmark gaps" in `benches/endpoint_benchmarks.rs`. **Bench-only; no production code touched.**

| Benchmark | Why |
|-----------|-----|
| `POST /anything (with body)` | the body-echo path (existing benches only covered empty-body GETs + a tiny POST) |
| `cookies roundtrip (set + read)` | `/cookies/set` then `/cookies` (parse) — the Set-Cookie + Cookie-parse cost |
| `GET /redirect/3` | the redirect-chain handler |
| `GET /get (full middleware stack)` | runs through the real `build_app()` stack; pairs with the existing bare `GET /get` to **quantify middleware overhead** |
| `Metrics::record_request (4 tasks x 100)` | concurrent recording to surface lock contention on the `RwLock<HashMap>` — the baseline a future DashMap/sharded swap (T3) would beat |

`bench_app()` now also merges the `redirect` and `cookies` routers; a new `bench_full_app()` wires the full stack.

## Local results (reduced sample)

```
GET /get                          2.69 µs
GET /get (full middleware stack)  7.16 µs   <- ~2.7x overhead
POST /anything (with body)        3.31 µs
cookies roundtrip (set + read)    4.79 µs
GET /redirect/3                   1.45 µs
Metrics::record_request 4x100   134.65 µs
```

All ten benches run clean. `cargo fmt` + `clippy --all-targets --all-features -D warnings` clean; `cargo test --all-features` still 177 lib + 56 integration.

Ticks the T4 benchmark-gaps item in ROADMAP. After this, the only T4 item left is the dedicated MSRV (1.84) CI job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)