### PR TITLE
ci: Add an MSRV (1.84) check job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,34 @@ jobs:
       - name: Cargo check
         run: cargo check --all-targets --all-features
 
+  msrv:
+    name: MSRV (1.84)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      # Pin the declared MSRV (rust-version = "1.84" in Cargo.toml) so a break
+      # — e.g. from a dependency bump or a newer std/edition API — fails here at
+      # PR time instead of only at the rust:1.84 release Docker build. Checks the
+      # shipped crate (lib + bins); dev-deps (criterion/proptest/reqwest) are
+      # excluded since their MSRVs aren't part of rucho's contract.
+      - name: Install Rust 1.84
+        uses: dtolnay/rust-toolchain@1.84.0
+
+      - name: Cache cargo registry
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-msrv-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-msrv-
+
+      - name: Cargo check on MSRV
+        run: cargo check --all-features
+
   test:
     name: Test
     runs-on: ubuntu-latest

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -106,7 +106,7 @@ Coverage that backs the "more robust than httpbin" claim, and CI that catches th
 - [x] **[M]** Integration-test gaps — added `/delay` fires (≥1 s) + over-cap 400, `HEAD /get` empty body, response compression (gzip via a compression-enabled app), `/endpoints` shape, malformed-JSON → 400, and fuller `/status/:code` reason-phrase coverage (404/500/200, not just 418) (PR #156)
 - [x] **[M]** Property tests (`proptest`) — chaos roll stays in `[0,1)` and a `0.0` rate never fires; `/redirect/:n` points exactly one hop closer for all in-range `n` (so the chain is exactly `n` hops); `parse_cookies` never panics and never yields an empty cookie name (PR #157)
 - [x] **[M]** Benchmark gaps — added `POST /anything` (with body), cookies set+read roundtrip, `GET /redirect/3`, `GET /get` through the full middleware stack (vs the bare handler, to quantify overhead), and a 4-task concurrent `Metrics::record_request` contention bench (the baseline a DashMap/sharded swap would beat) (PR #158)
-- [ ] **[L]** MSRV CI job pinning `rust-version` from `Cargo.toml` (the CONTRIBUTING-vs-Dockerfile mismatch was resolved in #153 and `rust-version = "1.84"` is now declared; a dedicated CI job that builds on exactly 1.84 is the remaining piece)
+- [x] **[L]** MSRV CI job — a dedicated `MSRV (1.84)` job (`dtolnay/rust-toolchain@1.84.0` + `cargo check --all-features`, lib+bins only so dev-dep MSRVs don't leak in) now fails an MSRV break at PR time instead of only at the `rust:1.84` release Docker build. Verified the shipped crate compiles on 1.84.0 locally before adding (PR #159)
 
 ---
 


### PR DESCRIPTION
## What

Adds a dedicated `MSRV (1.84)` CI job that installs Rust **1.84.0** (the declared `rust-version`) and runs `cargo check --all-features`. An MSRV break — a dependency bump or a newer std/edition API — now fails at **PR time** instead of only at the `rust:1.84` release Docker build.

```yaml
  msrv:
    name: MSRV (1.84)
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v6
      - name: Install Rust 1.84
        uses: dtolnay/rust-toolchain@1.84.0
      - ... cache (own key) ...
      - name: Cargo check on MSRV
        run: cargo check --all-features
```

## Design choices

- **`cargo check --all-features`, not `--all-targets`** — scopes the MSRV to the *shipped* crate (lib + bins). `--all-targets` would compile tests/benches and drag dev-dependency MSRVs (criterion, proptest, reqwest) into rucho's contract, which could fail spuriously; those aren't part of what we ship. This matches what the release Docker build cares about.
- **Runs in parallel** (no `needs:`), with its own `-cargo-msrv-` cache key so 1.84 artifacts don't collide with the stable jobs.
- **Verified before adding**: `cargo +1.84.0 check --all-features` passes locally (the whole crate, including the new TLS acceptor on tokio-rustls 0.26/rustls 0.23, compiles on 1.84.0) — so this job won't red-fail its own PR.

Completes the **T4 (Testing & Quality)** tier. (Per the side-project scope lens, confirmed with the maintainer before adding a CI job.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)