### PR TITLE
docs: Dedup the project-structure block (README canonical)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -131,60 +131,11 @@ Closes #42
 
 ## Project Structure
 
-```
-benches/                         # Criterion benchmarks (cargo bench)
-├── response_benchmarks.rs       # Response building microbenchmarks
-└── endpoint_benchmarks.rs       # Full request cycle benchmarks
-debian/man/                      # Debian package extras
-└── rucho.1                      # Man page (man rucho)
-tests/                           # Integration tests (cargo test)
-└── integration.rs               # HTTP integration tests (reqwest)
-src/
-├── main.rs              # Application entrypoint
-├── lib.rs               # Library exports
-├── cli/                 # CLI argument parsing and commands
-│   ├── mod.rs
-│   └── commands.rs      # start, stop, status, version handlers
-├── routes/              # HTTP route handlers
-│   ├── mod.rs
-│   ├── base64.rs        # /base64/:encoded endpoint
-│   ├── bytes.rs         # /bytes/:n endpoint
-│   ├── cache.rs         # /cache + /cache/:n endpoints
-│   ├── content_types.rs # /xml + /html endpoints
-│   ├── cookies.rs       # /cookies endpoints
-│   ├── core_routes.rs   # Core echo + utility endpoints
-│   ├── delay.rs         # /delay/:n endpoint
-│   ├── drip.rs          # /drip slow-streaming endpoint
-│   ├── encoding.rs      # /gzip + /deflate + /brotli endpoints
-│   ├── healthz.rs       # /healthz endpoint
-│   ├── image.rs         # /image/:format endpoint
-│   ├── metrics.rs       # /metrics endpoint handler
-│   ├── range.rs         # /range/:n endpoint
-│   ├── redirect.rs      # /redirect/:n endpoint
-│   └── response_headers.rs # /response-headers endpoint
-├── server/              # Server setup and orchestration
-│   ├── mod.rs
-│   ├── chaos_layer.rs   # Chaos engineering middleware
-│   ├── http.rs          # HTTP/HTTPS listener setup
-│   ├── metrics_layer.rs # Metrics collection middleware
-│   ├── tcp.rs           # TCP echo listener
-│   ├── timing_layer.rs  # Request timing middleware
-│   ├── udp.rs           # UDP echo listener
-│   ├── request_id.rs    # X-Request-Id correlation middleware
-│   ├── tls.rs           # TLS-info acceptor (HTTPS `tls` echo)
-│   └── shutdown.rs      # Graceful shutdown handling
-├── tcp_udp_handlers.rs  # TCP/UDP echo protocol handlers
-└── utils/               # Utility modules
-    ├── mod.rs
-    ├── config.rs        # Configuration loading
-    ├── constants.rs     # Centralized constants
-    ├── error_response.rs
-    ├── json_response.rs
-    ├── metrics.rs       # Metrics data structures
-    ├── pid.rs           # PID file management
-    ├── server_config.rs # Listener and TLS configuration
-    └── timing.rs        # Timing utilities
-```
+The canonical project layout lives in the **[Project Structure section of the
+README](README.md#project-structure)** — see it for the annotated `src/` tree.
+For a deeper, architecture-oriented walkthrough of the same layout (module
+responsibilities, the request lifecycle, the middleware stack), see
+[`docs/INTERNALS.md`](docs/INTERNALS.md).
 
 ## Releasing
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -135,7 +135,7 @@ Tell the dual-mission story and end the doc sprawl.
 - [x] **[H]** "Why rucho?" section at the top of the README — vs httpbin / go-httpbin (speed, robustness, TCP/UDP, TLS, chaos) + the Kong-upstream pitch (PR #137)
 - [x] **[H]** "Using rucho as a Kong upstream" section + a declarative `kong.yaml` snippet (PR #137)
 - [x] **[M]** "Using rucho in Kong Mesh" snippet — Kuma sidecar injection + a MeshRetry example (PR #137)
-- [ ] **[M]** Deduplicate the project-structure block (one canonical source; README/CONTRIBUTING/INTERNALS currently triplicate it — this ROADMAP no longer renders it either)
+- [x] **[M]** Deduplicate the project-structure block — README's tree is now the single canonical source; CONTRIBUTING points to it instead of carrying an identical copy. INTERNALS keeps its deeper architecture-oriented tree (a distinct artifact, not a verbatim dup) (PR #160)
 - [ ] **[M]** Deduplicate config-field tables — canonical source is `config_samples/rucho.conf.default`; link, don't re-render
 - [ ] **[M]** Replace `docs/API_REFERENCE.md` with a one-pager linking `/swagger-ui` as canonical + 3–4 example responses (the hand-written table caused the v1.4.4 missing-endpoint fix)
 - [x] **[M]** Align MSRV — set `rust-version = "1.84"` in `Cargo.toml` (the `rust:1.84` release Docker image builds the project, verifying it compiles) and updated CONTRIBUTING from the stale "1.70+" to "1.84+" (PR #153)


### PR DESCRIPTION
## What

First of the **T6** doc-dedup items. README and CONTRIBUTING carried an *identical* ~50-line `src/` tree. This makes **README's tree the single canonical "Project Structure" overview** and replaces CONTRIBUTING's copy with a short pointer to it (plus a link to `docs/INTERNALS.md` for the deeper walkthrough).

## Why this split

- **README** = canonical user-facing overview (the entry point everyone reads first).
- **CONTRIBUTING** = now points to README instead of carrying a drift-prone duplicate.
- **INTERNALS** = left untouched: its tree is a distinct, richer, architecture-oriented artifact woven into that doc's walkthrough (different style, per-file responsibilities, surrounding prose) — not a verbatim dup, so nothing is lost.

(Per your call: README canonical, INTERNALS kept.)

Docs-only; no code touched. Ticks the T6 project-structure-dedup item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)