### PR TITLE
docs: Dedup config-field tables (drop INTERNALS §7.2 re-render)

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,8 @@ Rucho loads configuration in this order (later overrides earlier):
 | `max_body_size_bytes`       | `2097152` (2 MiB)    | `RUCHO_MAX_BODY_SIZE_BYTES`    | Max request body size in bytes (global limit; 413 if exceeded) |
 | `chaos_mode`                | (none)               | `RUCHO_CHAOS_MODE`             | Enable [chaos types](#chaos-engineering-mode) |
 
+> The `chaos_*` knobs have their own table under [Chaos Engineering Mode](#chaos-engineering-mode). For a ready-to-edit file listing every key with its default, see [`config_samples/rucho.conf.default`](config_samples/rucho.conf.default).
+
 ### HTTPS Configuration
 
 To enable HTTPS, add `ssl` suffix to the listen address:

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -136,7 +136,7 @@ Tell the dual-mission story and end the doc sprawl.
 - [x] **[H]** "Using rucho as a Kong upstream" section + a declarative `kong.yaml` snippet (PR #137)
 - [x] **[M]** "Using rucho in Kong Mesh" snippet — Kuma sidecar injection + a MeshRetry example (PR #137)
 - [x] **[M]** Deduplicate the project-structure block — README's tree is now the single canonical source; CONTRIBUTING points to it instead of carrying an identical copy. INTERNALS keeps its deeper architecture-oriented tree (a distinct artifact, not a verbatim dup) (PR #160)
-- [ ] **[M]** Deduplicate config-field tables — canonical source is `config_samples/rucho.conf.default`; link, don't re-render
+- [x] **[M]** Deduplicate config-field tables — removed the drift-prone third copy: INTERNALS §7.2 "Complete Field Reference" now points to the README's Parameters + Chaos tables (the canonical doc reference), with types in the §7.1 struct and `config_samples/rucho.conf.default` as the runnable example. (Kept the README table rather than gutting it to a bare link, since it carries the user-facing descriptions — maintainer call) (PR #161)
 - [ ] **[M]** Replace `docs/API_REFERENCE.md` with a one-pager linking `/swagger-ui` as canonical + 3–4 example responses (the hand-written table caused the v1.4.4 missing-endpoint fix)
 - [x] **[M]** Align MSRV — set `rust-version = "1.84"` in `Cargo.toml` (the `rust:1.84` release Docker image builds the project, verifying it compiles) and updated CONTRIBUTING from the stale "1.70+" to "1.84+" (PR #153)
 - [ ] **[L]** Group README features under sub-headers (Protocol / Resilience / Observability / Deployment); explain why `compression_enabled` defaults off; mention the gitignored `tasks/` convention

--- a/docs/INTERNALS.md
+++ b/docs/INTERNALS.md
@@ -1349,37 +1349,17 @@ pub struct ChaosConfig {
 
 ### 7.2 Complete Field Reference
 
-| Field | Type | Default | Config Key | Env Var |
-|-------|------|---------|-----------|---------|
-| `prefix` | `String` | `"/usr/local/rucho"` | `prefix` | `RUCHO_PREFIX` |
-| `log_level` | `String` | `"info"` | `log_level` | `RUCHO_LOG_LEVEL` |
-| `log_format` | `String` | `"text"` | `log_format` | `RUCHO_LOG_FORMAT` |
-| `server_listen_primary` | `String` | `"0.0.0.0:8080"` | `server_listen_primary` | `RUCHO_SERVER_LISTEN_PRIMARY` |
-| `server_listen_secondary` | `String` | `"0.0.0.0:9090"` | `server_listen_secondary` | `RUCHO_SERVER_LISTEN_SECONDARY` |
-| `server_listen_tcp` | `Option<String>` | `None` | `server_listen_tcp` | `RUCHO_SERVER_LISTEN_TCP` |
-| `server_listen_udp` | `Option<String>` | `None` | `server_listen_udp` | `RUCHO_SERVER_LISTEN_UDP` |
-| `ssl_cert` | `Option<String>` | `None` | `ssl_cert` | `RUCHO_SSL_CERT` |
-| `ssl_key` | `Option<String>` | `None` | `ssl_key` | `RUCHO_SSL_KEY` |
-| `pid_file` | `String` | `"/var/run/rucho/rucho.pid"` | `pid_file` | `RUCHO_PID_FILE` |
-| `metrics_enabled` | `bool` | `false` | `metrics_enabled` | `RUCHO_METRICS_ENABLED` |
-| `compression_enabled` | `bool` | `false` | `compression_enabled` | `RUCHO_COMPRESSION_ENABLED` |
-| `request_id_enabled` | `bool` | `true` | `request_id_enabled` | `RUCHO_REQUEST_ID_ENABLED` |
-| `http_keep_alive_timeout` | `u64` | `75` | `http_keep_alive_timeout` | `RUCHO_HTTP_KEEP_ALIVE_TIMEOUT` |
-| `tcp_keepalive_time` | `u64` | `60` | `tcp_keepalive_time` | `RUCHO_TCP_KEEPALIVE_TIME` |
-| `tcp_keepalive_interval` | `u64` | `15` | `tcp_keepalive_interval` | `RUCHO_TCP_KEEPALIVE_INTERVAL` |
-| `tcp_keepalive_retries` | `u32` | `5` | `tcp_keepalive_retries` | `RUCHO_TCP_KEEPALIVE_RETRIES` |
-| `tcp_nodelay` | `bool` | `true` | `tcp_nodelay` | `RUCHO_TCP_NODELAY` |
-| `header_read_timeout` | `u64` | `30` | `header_read_timeout` | `RUCHO_HEADER_READ_TIMEOUT` |
-| `max_body_size_bytes` | `usize` | `2097152` | `max_body_size_bytes` | `RUCHO_MAX_BODY_SIZE_BYTES` |
-| `chaos.modes` | `Vec<String>` | `[]` | `chaos_mode` | `RUCHO_CHAOS_MODE` |
-| `chaos.failure_rate` | `f64` | `0.0` | `chaos_failure_rate` | `RUCHO_CHAOS_FAILURE_RATE` |
-| `chaos.failure_codes` | `Vec<u16>` | `[]` | `chaos_failure_codes` | `RUCHO_CHAOS_FAILURE_CODES` |
-| `chaos.delay_rate` | `f64` | `0.0` | `chaos_delay_rate` | `RUCHO_CHAOS_DELAY_RATE` |
-| `chaos.delay_ms` | `String` | `""` | `chaos_delay_ms` | `RUCHO_CHAOS_DELAY_MS` |
-| `chaos.delay_max_ms` | `u64` | `0` | `chaos_delay_max_ms` | `RUCHO_CHAOS_DELAY_MAX_MS` |
-| `chaos.corruption_rate` | `f64` | `0.0` | `chaos_corruption_rate` | `RUCHO_CHAOS_CORRUPTION_RATE` |
-| `chaos.corruption_type` | `String` | `""` | `chaos_corruption_type` | `RUCHO_CHAOS_CORRUPTION_TYPE` |
-| `chaos.inform_header` | `bool` | `true` | `chaos_inform_header` | `RUCHO_CHAOS_INFORM_HEADER` |
+To avoid the field list drifting across three places, the canonical reference
+lives in the README:
+
+- **General config** — defaults, env vars, and descriptions: the
+  [Parameters table](../README.md#parameters).
+- **Chaos knobs** (`chaos_*`) — the
+  [Chaos Engineering Mode table](../README.md#chaos-engineering-mode).
+- **Rust types** for each field — the `Config` / `ChaosConfig` struct
+  definitions in §7.1 above.
+- **Runnable example** — `config_samples/rucho.conf.default`, every key with its
+  default, commented.
 
 ### 7.3 Loading Precedence
 


### PR DESCRIPTION
## What

Second **T6** doc-dedup item. The config field list lived in three places — README's Parameters/Chaos tables, INTERNALS **§7.2 "Complete Field Reference"**, and `config_samples/rucho.conf.default` — so adding a field meant touching all three (and #154 caught one that had already drifted).

This replaces INTERNALS §7.2's full table with a pointer to the canonical sources, and adds a short cross-link under README's Parameters table.

## Why nothing is lost

§7.2's table had three "columns" of value; each is already covered elsewhere:

| §7.2 column | Now lives in |
|-------------|--------------|
| field / default / env var (general) | README [Parameters table](README.md#parameters) |
| `chaos_*` fields | README [Chaos Engineering Mode table](README.md#chaos-engineering-mode) (verified it includes all of them, incl. `chaos_inform_header`) |
| Rust **type** | the `Config` / `ChaosConfig` structs in INTERNALS §7.1, immediately above |
| runnable form | `config_samples/rucho.conf.default` |

## Decision

Kept the README table as the canonical **doc** reference rather than reducing it to a bare link to `config_samples` (the roadmap's literal wording) — the README table carries the user-facing descriptions, and gutting it would hurt UX. config_samples remains the canonical **runnable** reference. (Maintainer call.)

Docs-only; no code touched. Ticks the T6 config-table-dedup item. Last T6 item: replacing `API_REFERENCE.md` with a Swagger one-pager.

🤖 Generated with [Claude Code](https://claude.com/claude-code)