### PR TITLE
docs: Add CHANGELOG Performance category + compare-links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,9 +31,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Declared a minimum supported Rust version — `rust-version = "1.84"` in `Cargo.toml`, matching the release Docker image (`rust:1.84`). CONTRIBUTING's stale "Rust 1.70+" prerequisite is corrected to "1.84+".
-- Chaos middleware now uses a per-thread cached RNG (`thread_local!` `StdRng`, seeded once from entropy) instead of constructing and re-seeding a `StdRng` from `thread_rng()` on every request. The v1.4.6 changelog described this optimization, but the implementation had continued to re-seed per request — this lands it for real. Internal only; chaos injection behavior is unchanged.
 - `/status/:code` now returns a JSON body `{ "status", "reason" }` carrying the canonical reason phrase (e.g. `"Not Found"`) instead of an empty body, while the HTTP status line still carries the requested code — an inspection-fidelity improvement over httpbin.
 - `/redirect/:n` now emits an `X-Redirect-Count` response header (remaining hops) on each 302, so clients can observe chain progress without parsing the `Location` URL.
+
+### Performance
+- Chaos middleware now uses a per-thread cached RNG (`thread_local!` `StdRng`, seeded once from entropy) instead of constructing and re-seeding a `StdRng` from `thread_rng()` on every request. The v1.4.6 changelog described this optimization, but the implementation had continued to re-seed per request — this lands it for real. Internal only; chaos injection behavior is unchanged.
 
 ### Fixed
 - Server no longer refuses to start when the PID file can't be written (read-only filesystem, missing parent directory). `handle_start_command` now logs a warning and continues instead of returning failure and aborting startup — so `--read-only` containers run. The PID file only backs `rucho stop`/`status`; signal-based shutdown (SIGTERM / Ctrl+C) is unaffected.
@@ -220,3 +222,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Request tracing and logging
 - CORS support (permissive)
 - Pretty JSON output (`?pretty=true`)
+
+<!-- Version compare links (tagged releases only; 0.1.0 / 0.0.1 were never tagged). -->
+[Unreleased]: https://github.com/rumpus/rucho/compare/v1.4.6...HEAD
+[1.4.6]: https://github.com/rumpus/rucho/compare/v1.4.5...v1.4.6
+[1.4.5]: https://github.com/rumpus/rucho/compare/v1.4.4...v1.4.5
+[1.4.4]: https://github.com/rumpus/rucho/compare/v1.4.3...v1.4.4
+[1.4.3]: https://github.com/rumpus/rucho/compare/v1.4.2...v1.4.3
+[1.4.2]: https://github.com/rumpus/rucho/compare/v1.4.1...v1.4.2
+[1.4.1]: https://github.com/rumpus/rucho/compare/v1.4.0...v1.4.1
+[1.4.0]: https://github.com/rumpus/rucho/compare/v1.3.1...v1.4.0
+[1.3.1]: https://github.com/rumpus/rucho/compare/v1.3.0...v1.3.1
+[1.3.0]: https://github.com/rumpus/rucho/compare/v1.2.0...v1.3.0
+[1.2.0]: https://github.com/rumpus/rucho/compare/v1.1.0...v1.2.0
+[1.1.0]: https://github.com/rumpus/rucho/compare/v1.0.0...v1.1.0
+[1.0.0]: https://github.com/rumpus/rucho/releases/tag/v1.0.0

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -142,7 +142,7 @@ Tell the dual-mission story and end the doc sprawl.
 - [x] **[L]** Grouped README features under sub-headers (Echo & inspection / Controllable upstream behaviors / Protocol & connection / Observability / Deployment & ops); filled in previously-unlisted features (`/metrics`, the inspection endpoints); explained why `compression_enabled` defaults off; noted the gitignored `tasks/` convention in CONTRIBUTING (PR #163)
 - [~] **[L]** ~~Consolidate USAGE_EXAMPLES curl/Python/JS triplets~~ — **won't do**: ~17 `<details>` wraps across a 1411-line file is high churn for a purely cosmetic gain, and the triplets are useful as-is (maintainer call to skip)
 - [ ] **[L]** Add `SECURITY.md` (disclosure + supported versions) and a lightweight `ARCHITECTURE.md`
-- [ ] **[L]** CHANGELOG: add a "Performance" sub-category; add compare-link references at the bottom
+- [x] **[L]** CHANGELOG: added a `### Performance` sub-category (moved the chaos-RNG optimization there from Changed) and compare-link references at the bottom for every tagged release (`v1.0.0`…`v1.4.6` + `Unreleased`); `0.1.0`/`0.0.1` were never tagged so they stay plain (PR #165)
 - [x] **[L]** `config_samples/rucho.conf.default` — consistent style: every field is now shown commented-out at its default with a one-line description (was a mix of active core fields + commented advanced ones); the file documents the full config surface and is a no-op when copied as-is (PR #164)
 - [ ] **[L]** Evaluate auto-generating internals from `///` doc comments (`cargo doc`); consider splitting INTERNALS by concern
 


### PR DESCRIPTION
## What

Two Keep-a-Changelog tidy-ups (T6 `[L]`):

- **`### Performance` sub-category** under `[Unreleased]` — moved the chaos-RNG optimization there from `Changed` (it's a purely internal perf change, not a behavior change).
- **Compare-link references** at the bottom for every tagged release (`v1.0.0`…`v1.4.6`) plus `[Unreleased] → v1.4.6...HEAD`, so the `## [x.y.z]` version headers render as clickable diffs. `0.1.0` / `0.0.1` were never tagged, so they intentionally stay plain (a comment notes this).

## Follow-up for the release flow

Once compare-links exist they need release-time maintenance: cutting a release should also point `[Unreleased]` at the new tag and add a `[<version>]: …compare/<prev>...<new>` line. Worth adding to the `/release` checklist (CLAUDE.md) — I didn't touch that file since it's your local config.

Docs-only; no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)