### PR TITLE
docs: Add a minimal SECURITY.md

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -141,10 +141,10 @@ Tell the dual-mission story and end the doc sprawl.
 - [x] **[M]** Align MSRV — set `rust-version = "1.84"` in `Cargo.toml` (the `rust:1.84` release Docker image builds the project, verifying it compiles) and updated CONTRIBUTING from the stale "1.70+" to "1.84+" (PR #153)
 - [x] **[L]** Grouped README features under sub-headers (Echo & inspection / Controllable upstream behaviors / Protocol & connection / Observability / Deployment & ops); filled in previously-unlisted features (`/metrics`, the inspection endpoints); explained why `compression_enabled` defaults off; noted the gitignored `tasks/` convention in CONTRIBUTING (PR #163)
 - [~] **[L]** ~~Consolidate USAGE_EXAMPLES curl/Python/JS triplets~~ — **won't do**: ~17 `<details>` wraps across a 1411-line file is high churn for a purely cosmetic gain, and the triplets are useful as-is (maintainer call to skip)
-- [ ] **[L]** Add `SECURITY.md` (disclosure + supported versions) and a lightweight `ARCHITECTURE.md`
+- [x] **[L]** Added a minimal `SECURITY.md` — test-target scope framing, latest-release-only support, and private GitHub vulnerability reporting (no over-promised SLA). `ARCHITECTURE.md` deliberately skipped: `docs/INTERNALS.md` already is the architecture doc, and a second one would re-introduce the sprawl T6 just removed (maintainer call) (PR #166)
 - [x] **[L]** CHANGELOG: added a `### Performance` sub-category (moved the chaos-RNG optimization there from Changed) and compare-link references at the bottom for every tagged release (`v1.0.0`…`v1.4.6` + `Unreleased`); `0.1.0`/`0.0.1` were never tagged so they stay plain (PR #165)
 - [x] **[L]** `config_samples/rucho.conf.default` — consistent style: every field is now shown commented-out at its default with a one-line description (was a mix of active core fields + commented advanced ones); the file documents the full config surface and is a no-op when copied as-is (PR #164)
-- [ ] **[L]** Evaluate auto-generating internals from `///` doc comments (`cargo doc`); consider splitting INTERNALS by concern
+- [~] **[L]** Evaluated auto-generating internals from `///` doc comments — **won't do**: `cargo doc` produces an API reference for public items, but `INTERNALS.md` is a hand-written architecture *narrative* (request lifecycle, middleware stack, design rationale) it can't replace; rucho is a binary so the generated docs aren't published anywhere either. Keeping INTERNALS hand-written. No split for now — it's large but well-sectioned with a ToC; revisit only if it becomes unwieldy
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,34 @@
+# Security Policy
+
+## Scope
+
+Rucho is an HTTP echo server and request inspector built for **testing and
+debugging** — and as a controllable upstream behind Kong Gateway / Kong Mesh.
+It is **not hardened for production**, is not intended to serve untrusted public
+traffic, and should not handle secrets. Run it in trusted test / CI / lab
+environments.
+
+Some deliberate behaviors follow from that purpose and are **features, not
+vulnerabilities**: it echoes request data back verbatim, can be told to inject
+failures / delays / corruption (chaos mode, off by default), and can emit
+arbitrary response headers (`/response-headers`). Don't expose an instance with
+those enabled to untrusted callers.
+
+## Supported versions
+
+This is a single-maintainer project; only the **latest release** receives fixes.
+
+| Version        | Supported |
+|----------------|-----------|
+| latest release | ✅        |
+| older          | ❌        |
+
+## Reporting a vulnerability
+
+Please report security issues **privately** via GitHub's
+[private vulnerability reporting](https://github.com/rumpus/rucho/security/advisories/new)
+— the **"Report a vulnerability"** button on the repository's **Security** tab —
+rather than opening a public issue.
+
+Acknowledgement is best-effort: this is a spare-time project, not a product with
+a response SLA.


### PR DESCRIPTION
## What

Adds a short, honest **SECURITY.md** scoped to what rucho actually is — a test/debug echo server and Kong upstream, not a production component:

- **Scope**: not hardened for production / untrusted traffic / secrets; plus a note that verbatim echo, chaos injection, and arbitrary response headers are intended *features*, not vulnerabilities.
- **Supported versions**: latest release only (single-maintainer project).
- **Reporting**: private vulnerability reporting via GitHub Security advisories, with an explicit best-effort (no-SLA) acknowledgement. No personal email exposed.

## What's skipped (your call, scope lens)

- **ARCHITECTURE.md** — `docs/INTERNALS.md` is already the architecture doc; a second one would re-introduce the sprawl T6 just removed.
- **Auto-generating internals from `///` (cargo doc)** — recorded as won't-do: `cargo doc` is an API reference for public items, not the architecture *narrative* (request lifecycle, middleware stack, rationale) INTERNALS provides, and rucho is a binary so the generated docs aren't published anywhere. INTERNALS stays hand-written; no split for now (large but well-sectioned with a ToC).

This resolves the **last T6 documentation items** — every roadmap item is now either shipped or consciously declined with rationale.

Docs-only; no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)