### PR TITLE
refactor: T3 code-quality quick wins

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -89,9 +89,9 @@ Keep the "fast, robust Rust" promise — hot-path correctness over premature opt
 
 - [x] **[M]** Metrics cardinality cap — `normalize_path` now buckets unknown `/cookies/{action}` → `/cookies/other` and any unmatched path → `/other` (via a `KNOWN_STATIC_PATHS` whitelist); also added the missing `/base64` arm and made every arm zero-allocation (PR #143)
 - [ ] **[M]** Metrics lock contention — swap `RwLock<HashMap>` for `DashMap` / sharded atomics. Only matters past ~10k rps; do it when a benchmark says so (`src/utils/metrics.rs`)
-- [ ] **[L]** Replace `RwLock<usize>` around `current_bucket_idx` with `AtomicUsize` (`src/utils/metrics.rs`)
-- [ ] **[L]** Replace `.unwrap()` in `head_handler` / `options_handler` response builders with `.expect("infallible: …")` — CLAUDE.md "no unwrap in production"
-- [ ] **[L]** Remove the dead `500` branch in `endpoints_handler` — `serde_json::to_value` on a `&'static` slice is infallible
+- [x] **[L]** Replaced `RwLock<usize>` around `current_bucket_idx` with `AtomicUsize` — it was only ever touched inside the `rolling_buckets` write lock, so the lock already serializes it; Relaxed atomics drop a lock acquisition per request (PR #167)
+- [x] **[L]** Replaced `.unwrap()` in `head_handler` / `options_handler` response builders with `.expect("infallible: …")` — CLAUDE.md "no unwrap in production" (PR #167)
+- [x] **[L]** Removed the dead `500` branch in `endpoints_handler` (and its now-impossible `500` from the OpenAPI annotation) — `serde_json::to_value` on a `&'static` slice is infallible (PR #167)
 - [ ] **[L]** Handler boilerplate DRY — a non-macro `echo_with_body(method, headers, body)` helper for POST/PUT/PATCH/DELETE. Deferred is defensible; revisit only if touched
 - [ ] **[L]** Module organization — move `src/tcp_udp_handlers.rs` → `src/server/echo.rs`; consider splitting `src/utils/`; refresh INTERNALS' architecture-walkthrough prose still citing `build_app`/`ApiDoc` under `main.rs`. (`ApiDoc`→`src/openapi.rs` + `build_app`→`src/app.rs` landed in PR #138.)
 

--- a/src/routes/core_routes.rs
+++ b/src/routes/core_routes.rs
@@ -546,7 +546,7 @@ pub async fn head_handler() -> impl IntoResponse {
     Response::builder()
         .status(axum::http::StatusCode::OK)
         .body(axum::body::Body::empty())
-        .unwrap()
+        .expect("infallible: OK status with an empty body")
 }
 
 // Handler for /endpoints
@@ -565,21 +565,16 @@ pub async fn head_handler() -> impl IntoResponse {
     get,
     path = "/endpoints",
     responses(
-        (status = 200, description = "Lists all available API endpoints", body = Vec<EndpointInfo>),
-        (status = 500, description = "Failed to serialize endpoint data")
+        (status = 200, description = "Lists all available API endpoints", body = Vec<EndpointInfo>)
     )
 )]
 pub async fn endpoints_handler(timing: Option<Extension<RequestTiming>>) -> Response {
-    match serde_json::to_value(API_ENDPOINTS) {
-        Ok(json_value) => {
-            let duration_ms = timing.map(|t| t.elapsed_ms());
-            format_json_response_with_timing(json!({"endpoints": json_value}), duration_ms)
-        }
-        Err(_) => format_error_response(
-            StatusCode::INTERNAL_SERVER_ERROR,
-            "Failed to serialize endpoint data.",
-        ),
-    }
+    // Serializing a `&'static [EndpointInfo]` (plain serializable structs) cannot
+    // fail, so there is no error path to handle.
+    let json_value = serde_json::to_value(API_ENDPOINTS)
+        .expect("infallible: API_ENDPOINTS is a static slice of plain serializable structs");
+    let duration_ms = timing.map(|t| t.elapsed_ms());
+    format_json_response_with_timing(json!({ "endpoints": json_value }), duration_ms)
 }
 
 // Handler for /uuid
@@ -925,7 +920,7 @@ pub async fn options_handler() -> impl IntoResponse {
             "GET, POST, PUT, PATCH, DELETE, OPTIONS, HEAD",
         )
         .body(axum::body::Body::empty())
-        .unwrap()
+        .expect("infallible: valid status, Allow header, and empty body")
 }
 
 #[cfg(test)]

--- a/src/utils/metrics.rs
+++ b/src/utils/metrics.rs
@@ -7,7 +7,7 @@
 //! - Rolling 1-hour window for all above metrics
 
 use std::collections::HashMap;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use std::sync::RwLock;
 use std::time::{Duration, Instant};
 
@@ -74,8 +74,10 @@ pub struct Metrics {
     endpoint_hits: RwLock<HashMap<String, u64>>,
     /// Rolling window buckets for time-based statistics.
     rolling_buckets: RwLock<Vec<TimeBucket>>,
-    /// Index of the current bucket being written to.
-    current_bucket_idx: RwLock<usize>,
+    /// Index of the current bucket being written to. Only ever accessed inside
+    /// the `rolling_buckets` write lock, so an atomic (not its own lock) is
+    /// enough — see `update_rolling_window`.
+    current_bucket_idx: AtomicUsize,
 }
 
 impl Default for Metrics {
@@ -96,7 +98,7 @@ impl Metrics {
             total_failures: AtomicU64::new(0),
             endpoint_hits: RwLock::new(HashMap::new()),
             rolling_buckets: RwLock::new(buckets),
-            current_bucket_idx: RwLock::new(0),
+            current_bucket_idx: AtomicUsize::new(0),
         }
     }
 
@@ -136,16 +138,20 @@ impl Metrics {
         is_failure: bool,
     ) {
         let mut buckets = self.rolling_buckets.write().unwrap();
-        let mut idx = self.current_bucket_idx.write().unwrap();
+        // `current_bucket_idx` is only ever touched here, under the buckets write
+        // lock, which already serializes it — so Relaxed atomics suffice (the
+        // AtomicUsize just provides interior mutability across `&self`).
+        let mut idx = self.current_bucket_idx.load(Ordering::Relaxed);
 
         // Check if current bucket is expired and we need to move to the next
-        if buckets[*idx].is_expired(now) {
-            *idx = (*idx + 1) % ROLLING_WINDOW_BUCKETS;
-            buckets[*idx].reset(now);
+        if buckets[idx].is_expired(now) {
+            idx = (idx + 1) % ROLLING_WINDOW_BUCKETS;
+            buckets[idx].reset(now);
+            self.current_bucket_idx.store(idx, Ordering::Relaxed);
         }
 
         // Record in current bucket
-        let bucket = &mut buckets[*idx];
+        let bucket = &mut buckets[idx];
         bucket.requests += 1;
         if is_success {
             bucket.successes += 1;


### PR DESCRIPTION
## What

Three small, low-risk hygiene fixes from the T3 `[L]` list. No behavior change.

### 1. `metrics`: `RwLock<usize>` → `AtomicUsize` for `current_bucket_idx`

`current_bucket_idx` is only ever read/written inside `update_rolling_window`, which holds the `rolling_buckets` **write** lock for the whole critical section — and it's read nowhere else. So its own `RwLock` was pure overhead: the buckets lock already serializes it. Switched to `AtomicUsize` with `Relaxed` ordering (the lock provides the happens-before; the atomic is just interior mutability across `&self`), dropping one lock acquisition per recorded request.

### 2. `core_routes`: `.unwrap()` → `.expect("infallible: …")`

In the `head_handler` and `options_handler` response builders — they use only hardcoded valid status/headers + an empty body, so the build cannot fail. Satisfies CLAUDE.md's "no `.unwrap()` in production code".

### 3. `core_routes`: drop the dead `500` branch in `endpoints_handler`

`serde_json::to_value` on a `&'static [EndpointInfo]` of plain serializable structs is infallible, so the `Err(_) => 500` arm was unreachable. Removed it (and the now-impossible `500` from the handler's `#[utoipa::path]` responses, so Swagger stays accurate).

## Verification

`cargo fmt` + `clippy --all-targets --all-features -D warnings` clean; **177 lib + 56 integration** tests pass (the metrics tests and the full-app metrics-middleware test confirm behavior is unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)