### PR TITLE
ci: Pin Windows check to windows-2022 (aws-lc-sys MSVC build break)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,12 @@ jobs:
 
   check-windows:
     name: Check (Windows)
-    runs-on: windows-latest
+    # Pinned to windows-2022: windows-latest moved to a newer MSVC toolchain
+    # (Visual Studio 18 / MSVC 14.51) that the rustls `aws-lc-sys` C build can't
+    # drive yet via its pinned cmake/cc ("C atomics require C11 or later";
+    # "couldn't determine visual studio generator"). The 2022 image's VS2022
+    # toolchain builds it cleanly. Revisit once aws-lc-sys/cmake/cc catch up.
+    runs-on: windows-2022
     steps:
       - uses: actions/checkout@v6
 


### PR DESCRIPTION
## Summary

Fixes the recurring red **Check (Windows)** job. It's a compile-only `cargo check` that started failing when GitHub's `windows-latest` image moved to a newer MSVC (Visual Studio 18 / MSVC 14.51) — rustls's transitive `aws-lc-sys` can't build its bundled C with that toolchain via its pinned `cmake`/`cc`:

```
vcruntime_c11_stdatomic.h: fatal error C1189: "C atomics require C11 or later"
cmake-0.1.54: couldn't determine visual studio generator
```

Nothing in rucho changed — it's the runner toolchain outpacing a dependency's native build, so it red-fails every PR. (`main` last passed Windows CI on 2026-05-31.)

## Fix

Pin the job to **`windows-2022`** (VS2022 / MSVC 14.4x) — the toolchain that built the project cleanly before the bump. Smallest possible fix, isolated to one CI job; no dependency or crypto-backend changes. Revisit when `aws-lc-sys`/`cmake`/`cc` gain VS18 support.

## Verification

I can't reproduce the runner failure locally (local MSVC builds `aws-lc-sys` fine), so this is validated by CI on this PR — the **Check (Windows)** job should now go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)