### PR TITLE
chore: Prepare v1.5.0 release

### DIFF
--- a/.claude/commands/add-endpoint.md
+++ b/.claude/commands/add-endpoint.md
@@ -10,7 +10,7 @@ Add the endpoint `$ARGUMENTS` to rucho. Follow the **"Adding a New Endpoint"** c
 3. Register the router in `build_app()` in **`src/app.rs`** — `.merge(rucho::routes::<name>::router())`.
 4. Add the handler path to the `ApiDoc` `#[openapi(paths(...))]` in **`src/openapi.rs`**.
 5. Integration test in `tests/integration.rs` (use the `spawn_app()` helper).
-6. Doc sweep: README endpoint table + project tree · `CHANGELOG [Unreleased]` · `ROADMAP` tick + priority rotation · `docs/API_REFERENCE.md` · `docs/INTERNALS.md` endpoint table · `docs/USAGE_EXAMPLES.md` · `CONTRIBUTING.md` routes block.
+6. Doc sweep: README endpoint table + project tree · `CHANGELOG [Unreleased]` · `ROADMAP` tick + priority rotation · `docs/API_REFERENCE.md` · `docs/INTERNALS.md` endpoint table · `docs/USAGE_EXAMPLES.md`.
 
 Watch the two classic traps (CLAUDE.md → **Common Mistakes**): forgetting the `build_app()` merge → the handler 404s at runtime even though unit tests pass; forgetting the `ApiDoc` path → it's missing from `/swagger-ui`.
 

--- a/.claude/commands/precommit.md
+++ b/.claude/commands/precommit.md
@@ -2,7 +2,7 @@
 description: Run rucho's CI-exact pre-commit gate (fmt, clippy, test) and fix anything it surfaces. Use before any commit/push to confirm a change is CI-green.
 ---
 
-Run rucho's CI-exact pre-commit gate and fix anything it surfaces. These three commands match `.github/workflows/ci.yml` exactly, so a locally-green run means CI will pass:
+Run rucho's CI-exact pre-commit gate and fix anything it surfaces. The `clippy` and `test` invocations match `.github/workflows/ci.yml` verbatim; `cargo fmt` formats in place (CI verifies the same formatting with `cargo fmt --all -- --check`). A locally-green run means CI will pass:
 
 ```bash
 cargo fmt

--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -14,6 +14,6 @@ Cut release **v$ARGUMENTS** of rucho. This ends in an irreversible tag-push that
 4. Run the CI-exact gate — `/precommit`.
 5. Commit `chore: Prepare v$ARGUMENTS release`, push the branch, open the PR. **Stop here and wait for the maintainer to merge.**
 6. After merge: `git checkout main && git pull`, then `git tag v$ARGUMENTS && git push origin v$ARGUMENTS`.
-7. The tag push runs `.github/workflows/release.yml`: fmt/clippy/test safety gate → release binary → GitHub release (CHANGELOG body + binary) → multi-arch Docker image (`rumpus/rucho:$ARGUMENTS` + `:latest`).
+7. The tag push runs `.github/workflows/release.yml`: fmt/clippy/test safety gate → release binary + `.deb` package → GitHub release (CHANGELOG body + binary + `.deb`) → multi-arch Docker image (`rumpus/rucho:$ARGUMENTS` + `:latest`).
 
 **Prerequisites:** repo secrets `DOCKERHUB_USERNAME` + `DOCKERHUB_TOKEN` must be configured.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.5.0] - 2026-06-26
+
 ### Added
 - `/anything?connection=close` connection-control knob — forces a `Connection: close` response header so the upstream hangs up after replying, letting you observe how a gateway re-establishes vs. reuses its upstream connection pool (something the gateway can't make the upstream do on its own). HTTP/1.1 only — `Connection` is a forbidden header in HTTP/2, so over h2 the directive is reflected in the body but not honored (guarded by `is_http1`). The honored outcome is echoed under a `connection` key in the JSON body. A per-request query directive (no config field), parsed from the raw query string so `/anything` keeps rejecting nothing.
 - `/base64/:encoded` endpoint — decode URL-safe base64 strings and return JSON with decoded content, UTF-8 validity, and byte length. Accepts URL-safe base64 with or without padding; standard base64 is attempted as a fallback. Input capped at 4096 bytes.
@@ -225,7 +227,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Pretty JSON output (`?pretty=true`)
 
 <!-- Version compare links (tagged releases only; 0.1.0 / 0.0.1 were never tagged). -->
-[Unreleased]: https://github.com/rumpus/rucho/compare/v1.4.6...HEAD
+[Unreleased]: https://github.com/rumpus/rucho/compare/v1.5.0...HEAD
+[1.5.0]: https://github.com/rumpus/rucho/compare/v1.4.6...v1.5.0
 [1.4.6]: https://github.com/rumpus/rucho/compare/v1.4.5...v1.4.6
 [1.4.5]: https://github.com/rumpus/rucho/compare/v1.4.4...v1.4.5
 [1.4.4]: https://github.com/rumpus/rucho/compare/v1.4.3...v1.4.4

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,7 @@ The full source tree is in **[README.md → Project Structure](README.md#project
 - Document all public functions with `///` doc comments
 - Use `format_json_response()` / `format_error_response()` — never build raw `Response` in handlers
 - No `.unwrap()` in production code (tests are fine)
-- New config fields: add to `Config` struct, `Default` impl, file parser, `load_env_overrides()`, and `config_samples/rucho.conf.default`
+- New config fields: add to `Config` struct, `Default` impl, the file parser, the `load_env_var!` block in `load_from_paths_with_env()` (`src/utils/config.rs`), and `config_samples/rucho.conf.default`
 - Keep `config_samples/rucho.conf.default` in sync — CI doesn't check this, so it's easy to forget
 
 ## Patterns — Copy These
@@ -62,7 +62,7 @@ The full source tree is in **[README.md → Project Structure](README.md#project
 1. **Forget route registration** — new handler works in unit tests but 404s at runtime because `build_app()` doesn't merge it
 2. **Forget OpenAPI** — endpoint works but missing from `/swagger-ui` because `ApiDoc` paths list wasn't updated
 3. **Break config_samples/** — add a config field but forget to add it to `rucho.conf.default`
-4. **Allocations in hot paths** — response formatting and metrics paths are perf-sensitive; use `Cow<str>` where possible (see `normalize_path()` in metrics)
+4. **Allocations in hot paths** — response formatting and metrics paths are perf-sensitive; use `Cow<str>` where possible (see `normalize_path()` in `src/server/metrics_layer.rs`)
 5. **Forget to update INTERNALS.md endpoint table** — `docs/INTERNALS.md` has a numbered table of all endpoints; new endpoints often get added to the router/OpenAPI but not the table
 
 ## Adding a New Endpoint
@@ -73,7 +73,7 @@ _Shortcut: `/add-endpoint <route>` runs this full checklist._
 4. Register in `build_app()` in `src/app.rs`: `.merge(rucho::routes::<name>::router())`
 5. Add handler path to `ApiDoc` `#[openapi(paths(...))]` in `src/openapi.rs`
 6. Add integration test in `tests/integration.rs`
-7. Docs to update: README endpoint table + project tree, CHANGELOG `[Unreleased]`, ROADMAP tick + Suggested Priority Order rotation, `docs/API_REFERENCE.md`, `docs/INTERNALS.md` endpoint table, `docs/USAGE_EXAMPLES.md`, `CONTRIBUTING.md` routes block
+7. Docs to update: README endpoint table + project tree, CHANGELOG `[Unreleased]`, ROADMAP tick + Suggested Priority Order rotation, `docs/API_REFERENCE.md`, `docs/INTERNALS.md` endpoint table, `docs/USAGE_EXAMPLES.md`
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -157,7 +157,7 @@ To cut a new release:
    git push origin v<version>
    ```
 
-The tag push triggers the workflow, which creates the GitHub release with the binary and pushes `rumpus/rucho:<version>` and `rumpus/rucho:latest` to Docker Hub.
+The tag push triggers the workflow, which creates the GitHub release with the binary and `.deb` package, and pushes `rumpus/rucho:<version>` and `rumpus/rucho:latest` to Docker Hub.
 
 ## Reporting Issues
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2021,7 +2021,7 @@ dependencies = [
 
 [[package]]
 name = "rucho"
-version = "1.4.6"
+version = "1.5.0"
 dependencies = [
  "axum",
  "axum-server",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rucho"
-version = "1.4.6"
+version = "1.5.0"
 description = "Rucho - An echo server and general HTTP request inspector."
 edition = "2021"
 rust-version = "1.84"

--- a/README.md
+++ b/README.md
@@ -219,13 +219,16 @@ debian/man/                      # Debian package extras
 tests/                           # Integration tests (cargo test)
 └── integration.rs               # HTTP integration tests (reqwest)
 src/
-├── main.rs              # Application entrypoint
+├── main.rs              # Application entrypoint + CLI dispatch
 ├── lib.rs               # Library exports
+├── app.rs               # build_app() — assembles routes + middleware stack
+├── openapi.rs           # ApiDoc — OpenAPI spec aggregator
 ├── cli/                 # CLI argument parsing and commands
 │   ├── mod.rs
 │   └── commands.rs      # start, stop, status, version handlers
 ├── routes/              # HTTP route handlers
 │   ├── mod.rs
+│   ├── assets/          # Embedded PNG/JPEG/WebP fixtures for /image
 │   ├── base64.rs        # /base64/:encoded endpoint
 │   ├── bytes.rs         # /bytes/:n endpoint
 │   ├── cache.rs         # /cache + /cache/:n endpoints

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -47,7 +47,7 @@ Items are tagged **[H]** / **[M]** / **[L]** by priority.
 - [x] Global request body-size cap — `DefaultBodyLimit` (`max_body_size_bytes`, default 2 MiB) on the whole router; closes the OOM vector (PR #109)
 
 ### Infrastructure
-- [x] Docker, Docker Compose, systemd, optimized multi-stage Dockerfile (189 MB), Docker Hub publishing
+- [x] Docker, Docker Compose, systemd, optimized multi-stage Dockerfile (~189 MB), Docker Hub publishing
 - [x] OpenAPI/Swagger UI; config files + env vars; PID file; GitHub Actions CI; permissive CORS
 - [x] `/metrics` (JSON, toggleable — not annotated in OpenAPI/`/endpoints` since it's toggle-gated; see T5); request tracing; request/response timing in echo responses
 
@@ -93,7 +93,7 @@ Keep the "fast, robust Rust" promise — hot-path correctness over premature opt
 - [x] **[L]** Replaced `.unwrap()` in `head_handler` / `options_handler` response builders with `.expect("infallible: …")` — CLAUDE.md "no unwrap in production" (PR #167)
 - [x] **[L]** Removed the dead `500` branch in `endpoints_handler` (and its now-impossible `500` from the OpenAPI annotation) — `serde_json::to_value` on a `&'static` slice is infallible (PR #167)
 - [ ] **[L]** Handler boilerplate DRY — a non-macro `echo_with_body(method, headers, body)` helper for POST/PUT/PATCH/DELETE. Deferred is defensible; revisit only if touched
-- [ ] **[L]** Module organization — move `src/tcp_udp_handlers.rs` → `src/server/echo.rs`; consider splitting `src/utils/`; refresh INTERNALS' architecture-walkthrough prose still citing `build_app`/`ApiDoc` under `main.rs`. (`ApiDoc`→`src/openapi.rs` + `build_app`→`src/app.rs` landed in PR #138.)
+- [ ] **[L]** Module organization — move `src/tcp_udp_handlers.rs` → `src/server/echo.rs`; consider splitting `src/utils/`. (INTERNALS' architecture prose that still cited `build_app`/`ApiDoc` under `main.rs` was corrected in the v1.5.0 docs sweep; the code move itself — `ApiDoc`→`src/openapi.rs`, `build_app`→`src/app.rs` — landed in PR #138.)
 
 ---
 
@@ -112,7 +112,7 @@ Coverage that backs the "more robust than httpbin" claim, and CI that catches th
 
 ## T5 — Build & Distribution
 
-Docker/release ergonomics at **single-maintainer scope** — explicitly *not* production-team tooling (see `feedback_side_project_tooling_scope.md`).
+Docker/release ergonomics at **single-maintainer scope** — explicitly *not* production-team tooling (see the **Non-Goals → Supply-chain / production-team tooling** section below).
 
 - [x] **[H]** Multi-arch Docker image (`linux/amd64,linux/arm64`) via `docker buildx` + QEMU — `release.yml` pushes a multi-arch manifest at release time; PR CI does a fast amd64-only sanity build (arm64 validated at release, so PRs stay fast) (PRs #139, #141)
 - [x] **[H]** SIGTERM graceful-shutdown handler — `shutdown.rs` now races `ctrl_c` with `tokio::signal::unix` `SignalKind::terminate()`, so Docker/K8s/Kong-Mesh SIGTERM drains in-flight requests (5s grace) instead of hard-killing. Unix-gated; non-Unix keeps SIGINT-only (PR #148)

--- a/debian/man/rucho.1
+++ b/debian/man/rucho.1
@@ -1,5 +1,5 @@
 .\" Man page for rucho(1)
-.TH RUCHO 1 "2026-02-17" "rucho 1.4.6" "Rucho Manual"
+.TH RUCHO 1 "2026-06-26" "rucho 1.5.0" "Rucho Manual"
 .SH NAME
 rucho \- HTTP echo server and request inspector
 .SH SYNOPSIS

--- a/docs/INTERNALS.md
+++ b/docs/INTERNALS.md
@@ -5,8 +5,8 @@
 > path in the codebase. It is intended as a developer reference — not user-facing
 > API docs.
 >
-> **Version:** 1.4.6
-> **Last updated:** 2026-02-17
+> **Version:** 1.5.0
+> **Last updated:** 2026-06-26
 
 ---
 
@@ -290,17 +290,27 @@ async fn main() {
 
 ### 3.1 Route Registration
 
-`build_app()` at `src/main.rs` constructs the Axum `Router`:
+`build_app()` at `src/app.rs` constructs the Axum `Router`:
 
 ```rust
-// src/main.rs
+// src/app.rs
 let mut app = Router::new()
     .merge(SwaggerUi::new("/swagger-ui").url("/api-docs/openapi.json", ApiDoc::openapi()))
-    .merge(rucho::routes::core_routes::router())  // 16 core routes
-    .merge(rucho::routes::healthz::router())       // /healthz
-    .merge(rucho::routes::delay::router())         // /delay/:n
-    .merge(rucho::routes::redirect::router())      // /redirect/:n
-    .merge(rucho::routes::cookies::router());      // /cookies, /cookies/set, /cookies/delete
+    .merge(crate::routes::core_routes::router())      // core echo + inspection routes
+    .merge(crate::routes::healthz::router())          // /healthz
+    .merge(crate::routes::delay::router())            // /delay/:n
+    .merge(crate::routes::redirect::router())         // /redirect/:n
+    .merge(crate::routes::cookies::router())          // /cookies, /cookies/set, /cookies/delete
+    .merge(crate::routes::base64::router())           // /base64/:encoded
+    .merge(crate::routes::bytes::router())            // /bytes/:n
+    .merge(crate::routes::cache::router())            // /cache, /cache/:n
+    .merge(crate::routes::drip::router())             // /drip
+    .merge(crate::routes::encoding::router())         // /gzip, /deflate, /brotli
+    .merge(crate::routes::response_headers::router()) // /response-headers
+    .merge(crate::routes::content_types::router())    // /xml, /html
+    .merge(crate::routes::image::router())            // /image/:format
+    .merge(crate::routes::range::router())            // /range/:n
+    .layer(DefaultBodyLimit::max(max_body_size_bytes));
 ```
 
 The core routes router (`src/routes/core_routes.rs`) registers:
@@ -327,9 +337,9 @@ Router::new()
 
 Conditional routes added in `build_app()`:
 
-- **`/metrics`** (GET) — only if `config.metrics_enabled` is true (`src/main.rs`)
+- **`/metrics`** (GET) — only if `config.metrics_enabled` is true (`src/app.rs`)
 - **Metrics middleware** — wraps all routes when metrics is enabled
-- **Chaos middleware** — wraps routes when `chaos.is_enabled()` (`src/main.rs`)
+- **Chaos middleware** — wraps routes when `chaos.is_enabled()` (`src/app.rs`)
 
 ### 3.2 Middleware Layer Order
 
@@ -817,7 +827,7 @@ for HEAD requests, but this handler explicitly returns an empty body.)
 
 **`endpoints_handler`** (`src/routes/core_routes.rs`):
 Serializes the static `API_ENDPOINTS` array into JSON. The array is defined
-at `src/routes/core_routes.rs` and lists all 36 endpoints with their
+at `src/routes/core_routes.rs` and lists all 37 endpoints with their
 path, method, and description.
 
 ### 5.5 Infrastructure Handlers
@@ -1336,6 +1346,7 @@ pub struct Config {
     pub tcp_keepalive_retries: u32,
     pub tcp_nodelay: bool,
     pub header_read_timeout: u64,          // seconds
+    pub max_body_size_bytes: usize,        // default 2 MiB; over-limit → 413
     pub chaos: ChaosConfig,
 }
 ```
@@ -2358,43 +2369,56 @@ down. Since they're stateless echo handlers, this is acceptable.
 
 ## 14. OpenAPI / Swagger Integration
 
-**File:** `src/main.rs`
+**File:** `src/openapi.rs`
 
 ```rust
 #[derive(OpenApi)]
 #[openapi(
     paths(
-        rucho::routes::core_routes::root_handler,
-        rucho::routes::core_routes::get_handler,
-        rucho::routes::core_routes::head_handler,
-        rucho::routes::core_routes::post_handler,
-        rucho::routes::core_routes::put_handler,
-        rucho::routes::core_routes::patch_handler,
-        rucho::routes::core_routes::delete_handler,
-        rucho::routes::core_routes::options_handler,
-        rucho::routes::core_routes::status_handler,
-        rucho::routes::core_routes::anything_handler,
-        rucho::routes::core_routes::anything_path_handler,
-        rucho::routes::core_routes::endpoints_handler,
-        rucho::routes::delay::delay_handler,
-        rucho::routes::healthz::healthz_handler,
-        rucho::routes::redirect::redirect_handler,
-        rucho::routes::cookies::cookies_handler,
-        rucho::routes::cookies::set_cookies_handler,
-        rucho::routes::cookies::delete_cookies_handler,
-        rucho::routes::core_routes::uuid_handler,
-        rucho::routes::core_routes::ip_handler,
-        rucho::routes::core_routes::user_agent_handler,
-        rucho::routes::core_routes::headers_handler,
+        crate::routes::core_routes::root_handler,
+        crate::routes::core_routes::get_handler,
+        crate::routes::core_routes::head_handler,
+        crate::routes::core_routes::post_handler,
+        crate::routes::core_routes::put_handler,
+        crate::routes::core_routes::patch_handler,
+        crate::routes::core_routes::delete_handler,
+        crate::routes::core_routes::options_handler,
+        crate::routes::core_routes::status_handler,
+        crate::routes::core_routes::anything_handler,
+        crate::routes::core_routes::anything_path_handler,
+        crate::routes::core_routes::endpoints_handler,
+        crate::routes::delay::delay_handler,
+        crate::routes::healthz::healthz_handler,
+        crate::routes::redirect::redirect_handler,
+        crate::routes::cookies::cookies_handler,
+        crate::routes::cookies::set_cookies_handler,
+        crate::routes::cookies::delete_cookies_handler,
+        crate::routes::base64::base64_handler,
+        crate::routes::bytes::bytes_handler,
+        crate::routes::cache::cache_handler,
+        crate::routes::cache::cache_seconds_handler,
+        crate::routes::drip::drip_handler,
+        crate::routes::encoding::gzip_handler,
+        crate::routes::encoding::deflate_handler,
+        crate::routes::encoding::brotli_handler,
+        crate::routes::response_headers::response_headers_handler,
+        crate::routes::content_types::xml_handler,
+        crate::routes::content_types::html_handler,
+        crate::routes::image::image_handler,
+        crate::routes::range::range_handler,
+        crate::routes::core_routes::uuid_handler,
+        crate::routes::core_routes::ip_handler,
+        crate::routes::core_routes::user_agent_handler,
+        crate::routes::core_routes::headers_handler,
     ),
     components(
-        schemas(EndpointInfo, rucho::routes::core_routes::Payload)
+        schemas(EndpointInfo, crate::routes::core_routes::Payload)
     ),
     tags(
         (name = "Rucho", description = "Rucho API")
     )
 )]
-struct ApiDoc;
+pub struct ApiDoc;
 ```
 
 **How it works:**
@@ -2407,7 +2431,7 @@ struct ApiDoc;
 3. The `components(schemas(...))` section registers reusable schema types.
 4. The `tags(...)` section defines API grouping for the Swagger UI.
 
-**Router mount** (`src/main.rs`):
+**Router mount** (`src/app.rs`):
 
 ```rust
 .merge(SwaggerUi::new("/swagger-ui").url("/api-docs/openapi.json", ApiDoc::openapi()))


### PR DESCRIPTION
## Summary

Prepares the **v1.5.0** release — version bump + CHANGELOG cut + a full, code-grounded docs/markdown/claude-file sweep.

`1.5.0` collects a large batch of **purely additive** work since `1.4.6` (no breaking changes), so by semver it's a minor bump:
- ~13 new endpoints: `/base64`, `/bytes/:n`, `/response-headers`, `/drip`, `/xml`, `/html`, `/image/:format`, `/range/:n`, `/gzip`, `/deflate`, `/brotli`, `/cache`, `/cache/:n`
- request-id middleware, `log_format=json`, configurable `pid_file`, `http_version` + `X-Response-Time` echo, TLS-info echo, and the `/anything?connection=close` knob.

## Release cut

- `Cargo.toml` + `Cargo.lock`: `1.4.6` → `1.5.0`
- `debian/man/rucho.1`: `.TH` → `rucho 1.5.0` / `2026-06-26`
- `CHANGELOG.md`: `[Unreleased]` → `[1.5.0] - 2026-06-26`, fresh empty `[Unreleased]`, `v1.4.6...v1.5.0` compare-link

## Docs sweep

Driven by a **14-agent audit** that cross-checked every shipped doc and the claude files against the actual code. Real drift fixed:

- **`docs/INTERNALS.md`** (the bulk): version header → 1.5.0; `build_app()`/`ApiDoc`/router-mount/conditional-route attributions corrected from `src/main.rs` → `src/app.rs` / `src/openapi.rs` (moved in #138); §3.1 router block regenerated to the real 14-module merge + `DefaultBodyLimit`; §14 `#[openapi(paths)]` block regenerated to all **34** handlers with `crate::` paths; §5.4 endpoint count `36` → `37`; §7.1 `Config` struct gains `max_body_size_bytes`.
- **`README.md`**: project tree gains `src/app.rs`, `src/openapi.rs`, and `routes/assets/`.
- **`CLAUDE.md`**: `load_env_overrides()` ghost ref → the real `load_env_var!` block in `load_from_paths_with_env()`; `normalize_path()` location → `src/server/metrics_layer.rs`; dropped the dead "CONTRIBUTING.md routes block" target.
- **`.claude/commands/`** + **`CONTRIBUTING.md`**: same routes-block fix; `.deb` release asset now documented (release.yml does build + attach it); `precommit.md` fmt wording.
- **`ROADMAP.md`**: dropped the dangling `feedback_side_project_tooling_scope.md` reference; noted the INTERNALS prose refresh; softened the Docker image size to `~189 MB`.

## Verification

`cargo fmt` · `clippy --all-targets --all-features -- -D warnings` (0 warnings) · `cargo test --all-features` (180 unit + 57 integration + 1 doc) — all green. Consistency grep confirms version reads 1.5.0 everywhere, no stale `main.rs`/`build_app` refs, endpoint count is 37 throughout.

## After merge

Per `.claude/commands/release.md`: `git checkout main && git pull`, then `git tag v1.5.0 && git push origin v1.5.0` (tag-push is the ask-gated step) → triggers `release.yml`: fmt/clippy/test gate → release binary + `.deb` → GitHub release → multi-arch Docker `rumpus/rucho:1.5.0` + `:latest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)