### PR TITLE
feat: Add DELETE /cookies (symmetry with GET /cookies/delete)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `DELETE /cookies` — RESTful symmetry with `GET /cookies/delete`: expires each cookie named in the query (`Max-Age=0`) and `302`-redirects to `/cookies`. Registered as the `DELETE` method on the existing `/cookies` path and shares a single `expire_cookies` helper with the GET form.
+
 ## [1.5.0] - 2026-06-26
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ rucho version  # Display version
 | ANY     | `/delay/:n`       | Delay response by n seconds (max 300)                |
 | ANY     | `/redirect/:n`    | Chain of n 302s (max 20; `X-Redirect-Count` header)  |
 | GET     | `/cookies`        | Inspect request cookies                              |
+| DELETE  | `/cookies`        | Delete cookies via query params and redirect         |
 | GET     | `/cookies/set`    | Set cookies (+ secure/httponly/samesite/max_age)     |
 | GET     | `/cookies/delete` | Delete cookies via query params and redirect         |
 | GET     | `/base64/:encoded`| Decode URL-safe base64 (max 4096 bytes)              |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -66,7 +66,7 @@ Make request inspection more correct, complete, and honest than httpbin & go-htt
 - [x] **[M]** `/cache` + `/cache/:n` — `/cache` returns `304` on `If-None-Match`/`If-Modified-Since`, else `200` + stable `ETag` + `Last-Modified`; `/cache/:n` sets `Cache-Control: public, max-age=n`. Conditional-request fidelity for watching a gateway/cache plugin react; no new deps (PR #144)
 - [x] **[M]** `parse_cookies` tolerates both `;` and `; ` separators (RFC 6265) — now splits on `;` with whitespace trimming (PR #145)
 - [x] **[M]** `/cookies/set` accepts attribute flags (`secure`, `httponly`, `samesite`, `max_age`, plus `path`/`domain`) via reserved query params — richer `Set-Cookie` fidelity for session inspection (PR #145)
-- [ ] **[L]** Support `DELETE` on `/cookies` — API symmetry with `GET /cookies/delete`
+- [x] **[L]** Support `DELETE` on `/cookies` — `DELETE /cookies?name…` expires the named cookies (`Max-Age=0`) and 302-redirects to `/cookies`, mirroring `GET /cookies/delete` via a shared `expire_cookies` helper (PR #174)
 
 ---
 

--- a/docs/INTERNALS.md
+++ b/docs/INTERNALS.md
@@ -135,7 +135,7 @@ src/main.rs
   |
   +-- rucho::cli::commands  (Args, CliCommand, handle_*_command)
   +-- rucho::routes::core_routes  (router, EndpointInfo)
-  +-- rucho::routes::cookies  (router, cookies_handler, set_cookies_handler, delete_cookies_handler)
+  +-- rucho::routes::cookies  (router, cookies_handler, set_cookies_handler, delete_cookies_handler, delete_cookies_method_handler)
   +-- rucho::routes::redirect  (router, redirect_handler)
   +-- rucho::server::chaos_layer  (chaos_middleware)
   +-- rucho::server::metrics_layer  (metrics_middleware)
@@ -704,6 +704,7 @@ The response travels back up through each middleware layer:
 | 35 | `/brotli` | GET | `brotli_handler` | `encoding.rs` |
 | 36 | `/cache` | GET | `cache_handler` | `cache.rs` |
 | 37 | `/cache/:n` | GET | `cache_seconds_handler` | `cache.rs` |
+| 38 | `/cookies` | DELETE | `delete_cookies_method_handler` | `cookies.rs` |
 
 > **`/anything` connection-control knob:** `ANY /anything?connection=close` makes
 > `anything_handler` set a `Connection: close` response header — but only on
@@ -827,7 +828,7 @@ for HEAD requests, but this handler explicitly returns an empty body.)
 
 **`endpoints_handler`** (`src/routes/core_routes.rs`):
 Serializes the static `API_ENDPOINTS` array into JSON. The array is defined
-at `src/routes/core_routes.rs` and lists all 37 endpoints with their
+at `src/routes/core_routes.rs` and lists all 38 endpoints with their
 path, method, and description.
 
 ### 5.5 Infrastructure Handlers
@@ -929,12 +930,12 @@ pub async fn set_cookies_handler(
 Each query parameter becomes a `Set-Cookie` response header with `Path=/`.
 Responds with a 302 redirect to `/cookies` so the client can see the result.
 
-**`delete_cookies_handler`** (`src/routes/cookies.rs`):
+**`delete_cookies_handler`** (`GET /cookies/delete`) and
+**`delete_cookies_method_handler`** (`DELETE /cookies`), both in
+`src/routes/cookies.rs`, delegate to a shared `expire_cookies` helper:
 
 ```rust
-pub async fn delete_cookies_handler(
-    axum::extract::Query(params): axum::extract::Query<HashMap<String, String>>,
-) -> Response {
+fn expire_cookies(params: &HashMap<String, String>) -> Response {
     let mut response = (StatusCode::FOUND, [(header::LOCATION, "/cookies")]).into_response();
     let response_headers = response.headers_mut();
     for name in params.keys() {
@@ -948,8 +949,9 @@ pub async fn delete_cookies_handler(
 }
 ```
 
-Each query parameter name generates a `Set-Cookie` header with `Max-Age=0` to
-expire the cookie. Like `set_cookies_handler`, redirects to `/cookies`.
+Each query-parameter name generates a `Set-Cookie` header with `Max-Age=0` to
+expire the cookie, then redirects to `/cookies`. The `DELETE /cookies` form is
+RESTful symmetry with `GET /cookies/delete` over the same shared logic.
 
 **`get_metrics`** (`src/routes/metrics.rs`):
 
@@ -2393,6 +2395,7 @@ down. Since they're stateless echo handlers, this is acceptable.
         crate::routes::cookies::cookies_handler,
         crate::routes::cookies::set_cookies_handler,
         crate::routes::cookies::delete_cookies_handler,
+        crate::routes::cookies::delete_cookies_method_handler,
         crate::routes::base64::base64_handler,
         crate::routes::bytes::bytes_handler,
         crate::routes::cache::cache_handler,

--- a/docs/USAGE_EXAMPLES.md
+++ b/docs/USAGE_EXAMPLES.md
@@ -727,6 +727,13 @@ curl -b cookies.txt http://localhost:8080/cookies
 # {"cookies": {"session": "abc123"}, ...}
 ```
 
+`DELETE /cookies?theme` is an equivalent RESTful alternative to step 3
+(`GET /cookies/delete?theme`) — same `Max-Age=0` expiry and redirect to `/cookies`:
+
+```bash
+curl -b cookies.txt -c cookies.txt -L -X DELETE "http://localhost:8080/cookies?theme"
+```
+
 **Python:**
 
 ```python

--- a/src/openapi.rs
+++ b/src/openapi.rs
@@ -33,6 +33,7 @@ use crate::routes::core_routes::EndpointInfo;
         crate::routes::cookies::cookies_handler,
         crate::routes::cookies::set_cookies_handler,
         crate::routes::cookies::delete_cookies_handler,
+        crate::routes::cookies::delete_cookies_method_handler,
         crate::routes::base64::base64_handler,
         crate::routes::bytes::bytes_handler,
         crate::routes::cache::cache_handler,

--- a/src/routes/cookies.rs
+++ b/src/routes/cookies.rs
@@ -133,6 +133,23 @@ pub async fn set_cookies_handler(
     response
 }
 
+/// Builds a `302`-to-`/cookies` response that expires each named cookie by
+/// setting `Max-Age=0`. Shared by `GET /cookies/delete` and `DELETE /cookies`.
+fn expire_cookies(params: &HashMap<String, String>) -> Response {
+    let mut response = (StatusCode::FOUND, [(header::LOCATION, "/cookies")]).into_response();
+    let response_headers = response.headers_mut();
+
+    for name in params.keys() {
+        if let Ok(cookie_val) =
+            header::HeaderValue::from_str(&format!("{name}=; Max-Age=0; Path=/"))
+        {
+            response_headers.append(header::SET_COOKIE, cookie_val);
+        }
+    }
+
+    response
+}
+
 /// Deletes cookies by setting `Max-Age=0` and redirects to `/cookies`.
 ///
 /// Each query parameter name is used to expire the corresponding cookie.
@@ -154,26 +171,42 @@ pub async fn set_cookies_handler(
 pub async fn delete_cookies_handler(
     axum::extract::Query(params): axum::extract::Query<HashMap<String, String>>,
 ) -> Response {
-    let mut response = (StatusCode::FOUND, [(header::LOCATION, "/cookies")]).into_response();
-    let response_headers = response.headers_mut();
+    expire_cookies(&params)
+}
 
-    for name in params.keys() {
-        if let Ok(cookie_val) =
-            header::HeaderValue::from_str(&format!("{name}=; Max-Age=0; Path=/"))
-        {
-            response_headers.append(header::SET_COOKIE, cookie_val);
-        }
-    }
-
-    response
+/// Deletes cookies via the `DELETE` method on `/cookies` — RESTful symmetry with
+/// `GET /cookies/delete`. Each query-parameter name expires the matching cookie
+/// (`Max-Age=0`), and the response is a `302` redirect to `/cookies`.
+///
+/// # Example
+///
+/// `DELETE /cookies?foo&theme` expires both cookies and redirects.
+#[utoipa::path(
+    delete,
+    path = "/cookies",
+    params(
+        ("" = HashMap<String, String>, Query, description = "Cookie names to delete")
+    ),
+    responses(
+        (status = 302, description = "Redirects to /cookies after deleting cookies")
+    )
+)]
+pub async fn delete_cookies_method_handler(
+    axum::extract::Query(params): axum::extract::Query<HashMap<String, String>>,
+) -> Response {
+    expire_cookies(&params)
 }
 
 /// Creates and returns the Axum router for the cookie endpoints.
 ///
-/// Registers `/cookies`, `/cookies/set`, and `/cookies/delete`.
+/// Registers `/cookies` (GET inspect + DELETE expire), `/cookies/set`, and
+/// `/cookies/delete`.
 pub fn router() -> Router {
     Router::new()
-        .route("/cookies", get(cookies_handler))
+        .route(
+            "/cookies",
+            get(cookies_handler).delete(delete_cookies_method_handler),
+        )
         .route("/cookies/set", get(set_cookies_handler))
         .route("/cookies/delete", get(delete_cookies_handler))
 }
@@ -294,6 +327,40 @@ mod tests {
             .filter_map(|v| v.to_str().ok())
             .collect();
 
+        assert_eq!(set_cookies.len(), 2);
+        assert!(set_cookies
+            .iter()
+            .any(|c| c.contains("foo=") && c.contains("Max-Age=0")));
+        assert!(set_cookies
+            .iter()
+            .any(|c| c.contains("theme=") && c.contains("Max-Age=0")));
+    }
+
+    #[tokio::test]
+    async fn test_delete_method_on_cookies_expires() {
+        // DELETE /cookies mirrors GET /cookies/delete (Max-Age=0 + 302 to /cookies).
+        let app = router();
+        let response = app
+            .oneshot(
+                Request::delete("/cookies?foo&theme")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::FOUND);
+        assert_eq!(
+            response.headers().get(header::LOCATION).unwrap(),
+            "/cookies"
+        );
+
+        let set_cookies: Vec<&str> = response
+            .headers()
+            .get_all(header::SET_COOKIE)
+            .iter()
+            .filter_map(|v| v.to_str().ok())
+            .collect();
         assert_eq!(set_cookies.len(), 2);
         assert!(set_cookies
             .iter()

--- a/src/routes/core_routes.rs
+++ b/src/routes/core_routes.rs
@@ -203,6 +203,11 @@ static API_ENDPOINTS: &[EndpointInfo] = &[
         description: "Returns all cookies from the request as JSON.",
     },
     EndpointInfo {
+        path: "/cookies",
+        method: "DELETE",
+        description: "Deletes (expires) cookies named in the query, then redirects to /cookies.",
+    },
+    EndpointInfo {
         path: "/cookies/set",
         method: "GET",
         description: "Sets cookies from query parameters and redirects to /cookies.",

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -369,6 +369,39 @@ async fn test_cookies_roundtrip() {
 }
 
 #[tokio::test]
+async fn test_delete_cookies_method() {
+    // DELETE /cookies?foo&theme expires both cookies (Max-Age=0) and 302s to /cookies.
+    let base = spawn_app().await;
+    let client = reqwest::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .unwrap();
+
+    let resp = client
+        .delete(format!("{base}/cookies?foo&theme"))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), 302);
+    assert_eq!(
+        resp.headers().get(reqwest::header::LOCATION).unwrap(),
+        "/cookies"
+    );
+
+    let set_cookies: Vec<String> = resp
+        .headers()
+        .get_all(reqwest::header::SET_COOKIE)
+        .iter()
+        .filter_map(|v| v.to_str().ok().map(String::from))
+        .collect();
+    assert_eq!(set_cookies.len(), 2);
+    assert!(set_cookies.iter().all(|c| c.contains("Max-Age=0")));
+    assert!(set_cookies.iter().any(|c| c.starts_with("foo=")));
+    assert!(set_cookies.iter().any(|c| c.starts_with("theme=")));
+}
+
+#[tokio::test]
 async fn test_base64_decode() {
     let base = spawn_app().await;
     // "Hello, Rucho!" -> SGVsbG8sIFJ1Y2hvIQ==


### PR DESCRIPTION
## Summary

First ROADMAP quick win: **`DELETE /cookies`** (T1 — echo/inspection fidelity).

`DELETE /cookies?foo&theme` expires each named cookie (`Max-Age=0`) and `302`-redirects to `/cookies` — RESTful symmetry with the existing `GET /cookies/delete`. The two forms share a single `expire_cookies()` helper (no duplicated logic); `DELETE` is registered as a method on the existing `/cookies` path.

## Changes

- **`src/routes/cookies.rs`** — extracted `expire_cookies()`; `delete_cookies_handler` (GET) now delegates to it, and a new `delete_cookies_method_handler` (DELETE) does too. Router: `/cookies` → `get(inspect).delete(expire)`. Unit test added.
- **`src/openapi.rs`** + **`API_ENDPOINTS`** — register the new operation so it appears in Swagger and `/endpoints`.
- **`tests/integration.rs`** — real-server test asserting `302` + `Max-Age=0` on both cookies (redirects disabled to inspect the 302 directly).
- **Docs** — README endpoint table, CHANGELOG `[Unreleased]`, ROADMAP tick, INTERNALS (table row #38, count 37→38, §14 paths, and the handler section refreshed to reflect the shared-helper refactor — it had embedded the old inline body), USAGE_EXAMPLES.

## Verification

`cargo fmt` · `clippy --all-targets --all-features -- -D warnings` (0) · `cargo test --all-features` (181 unit + 58 integration + 1 doc) — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)