### PR TITLE
feat: Document /metrics in OpenAPI / Swagger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - `DELETE /cookies` — RESTful symmetry with `GET /cookies/delete`: expires each cookie named in the query (`Max-Age=0`) and `302`-redirects to `/cookies`. Registered as the `DELETE` method on the existing `/cookies` path and shares a single `expire_cookies` helper with the GET form.
+- `/metrics` is now documented in the OpenAPI spec / Swagger UI — annotated with `#[utoipa::path]` and registered in `ApiDoc`, with a response description noting it's only mounted when `metrics_enabled`. Previously the endpoint was invisible in Swagger. It stays out of the `/endpoints` runtime list, which reflects always-mounted routes.
 
 ## [1.5.0] - 2026-06-26
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -124,7 +124,7 @@ Docker/release ergonomics at **single-maintainer scope** — explicitly *not* pr
 - [ ] **[L]** Parallelize CI `deb` + `docker` jobs (both depend only on `build`)
 - [ ] **[L]** Attach `SHA256SUMS` to GitHub releases — lightweight integrity, no recurring cost
 - [ ] **[L]** Apply TCP socket tuning to the HTTPS listener too — `configure_tcp_socket` currently runs only on the HTTP path, not the `bind_rustls` HTTPS listener (audit finding)
-- [ ] **[L]** Annotate `/metrics` with `#[utoipa::path]` (and optionally list it in `/endpoints`) so it's discoverable in Swagger when enabled — currently invisible in both (audit finding)
+- [x] **[L]** Annotated `/metrics` with `#[utoipa::path]` + registered it in `ApiDoc`, so it's now discoverable in Swagger / `openapi.json` (the response description notes it's only mounted when `metrics_enabled`). Deliberately left out of `/endpoints`, which lists always-mounted routes (PR #175)
 
 ---
 

--- a/docs/INTERNALS.md
+++ b/docs/INTERNALS.md
@@ -2413,6 +2413,7 @@ down. Since they're stateless echo handlers, this is acceptable.
         crate::routes::core_routes::ip_handler,
         crate::routes::core_routes::user_agent_handler,
         crate::routes::core_routes::headers_handler,
+        crate::routes::metrics::get_metrics,
     ),
     components(
         schemas(EndpointInfo, crate::routes::core_routes::Payload)

--- a/src/openapi.rs
+++ b/src/openapi.rs
@@ -51,6 +51,7 @@ use crate::routes::core_routes::EndpointInfo;
         crate::routes::core_routes::ip_handler,
         crate::routes::core_routes::user_agent_handler,
         crate::routes::core_routes::headers_handler,
+        crate::routes::metrics::get_metrics,
     ),
     components(
         schemas(EndpointInfo, crate::routes::core_routes::Payload)

--- a/src/routes/metrics.rs
+++ b/src/routes/metrics.rs
@@ -40,6 +40,13 @@ use crate::utils::metrics::Metrics;
 ///   }
 /// }
 /// ```
+#[utoipa::path(
+    get,
+    path = "/metrics",
+    responses(
+        (status = 200, description = "Request statistics as JSON: `all_time` totals plus a rolling `last_hour` window, each with total/success/failure counts and per-endpoint hits. Only mounted when `metrics_enabled` is set — otherwise the route returns 404.", body = serde_json::Value)
+    )
+)]
 pub async fn get_metrics(State(metrics): State<Arc<Metrics>>) -> impl IntoResponse {
     let snapshot = metrics.snapshot();
     (StatusCode::OK, Json(snapshot))


### PR DESCRIPTION
## Summary

Quick win **#2** (ROADMAP T5): make `/metrics` discoverable in Swagger.

`/metrics` was invisible in the OpenAPI spec — annotate `get_metrics` with `#[utoipa::path]` and register it in `ApiDoc`, so it now appears in **Swagger UI** and `openapi.json`. The response description notes it's only mounted when `metrics_enabled` (otherwise the route 404s).

## Scope decision

**Kept out of the `/endpoints` runtime list.** That list reflects *always-mounted* routes; `/metrics` is toggle-gated, so listing it there unconditionally would imply it's always available. Swagger — where the description can state the condition — is the right discoverability surface. (The ROADMAP item flagged `/endpoints` as optional.)

## Changes

- `src/routes/metrics.rs` — `#[utoipa::path]` on `get_metrics` (utoipa handles the `State` extractor fine).
- `src/openapi.rs` — register `get_metrics` in `ApiDoc`.
- Docs — CHANGELOG `[Unreleased]`, ROADMAP tick, INTERNALS §14 paths block kept in sync. (README already had the `/metrics` table row.)

## Verification

`cargo fmt` · `clippy --all-targets --all-features -- -D warnings` (0) · `cargo test --all-features` (181 unit + 58 integration + 1 doc) — all green. No spec/count test affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)