### PR TITLE
fix: Apply TCP socket tuning to the HTTPS listener

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `DELETE /cookies` — RESTful symmetry with `GET /cookies/delete`: expires each cookie named in the query (`Max-Age=0`) and `302`-redirects to `/cookies`. Registered as the `DELETE` method on the existing `/cookies` path and shares a single `expire_cookies` helper with the GET form.
 - `/metrics` is now documented in the OpenAPI spec / Swagger UI — annotated with `#[utoipa::path]` and registered in `ApiDoc`, with a response description noting it's only mounted when `metrics_enabled`. Previously the endpoint was invisible in Swagger. It stays out of the `/endpoints` runtime list, which reflects always-mounted routes.
 
+### Fixed
+- The HTTPS listener now receives the same TCP socket tuning (keep-alive, `TCP_NODELAY`) as the HTTP listener. `configure_tcp_socket` previously ran only on the HTTP path — the HTTPS path used `axum_server::Server::bind`, which binds internally and skipped it. The HTTPS path now binds + tunes the listener and attaches the TLS-info acceptor via `from_tcp`.
+
 ## [1.5.0] - 2026-06-26
 
 ### Added

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -123,7 +123,7 @@ Docker/release ergonomics at **single-maintainer scope** — explicitly *not* pr
 - [ ] **[L]** Alpine image variant (smaller image)
 - [ ] **[L]** Parallelize CI `deb` + `docker` jobs (both depend only on `build`)
 - [ ] **[L]** Attach `SHA256SUMS` to GitHub releases — lightweight integrity, no recurring cost
-- [ ] **[L]** Apply TCP socket tuning to the HTTPS listener too — `configure_tcp_socket` currently runs only on the HTTP path, not the `bind_rustls` HTTPS listener (audit finding)
+- [x] **[L]** Apply TCP socket tuning to the HTTPS listener — the HTTPS path now binds + `configure_tcp_socket`s the listener (keep-alive, `TCP_NODELAY`) before attaching the TLS-info acceptor via `from_tcp`, matching the HTTP path (it had used `Server::bind`, which binds internally and skipped the tuning) (PR #176)
 - [x] **[L]** Annotated `/metrics` with `#[utoipa::path]` + registered it in `ApiDoc`, so it's now discoverable in Swagger / `openapi.json` (the response description notes it's only mounted when `metrics_enabled`). Deliberately left out of `/endpoints`, which lists always-mounted routes (PR #175)
 
 ---

--- a/docs/INTERNALS.md
+++ b/docs/INTERNALS.md
@@ -1629,7 +1629,9 @@ run_server()
           +-- if is_ssl:
           |     setup_https_listener()  src/server/http.rs
           |       +-- try_load_rustls_config()  load TLS certs
-          |       +-- Server::bind().acceptor(TlsInfoAcceptor::new(cfg))
+          |       +-- TcpListener::bind() -> into_std()
+          |       +-- configure_tcp_socket()    set keepalive + nodelay (same as HTTP)
+          |       +-- Server::from_tcp().acceptor(TlsInfoAcceptor::new(cfg))
           |       |     wraps axum_server's RustlsAcceptor; reads the handshaken
           |       |     ServerConnection and injects a TlsConnectionInfo extension
           |       |     so /get & /anything can echo `tls` (src/server/tls.rs)
@@ -1646,10 +1648,11 @@ run_server()
                   +-- tokio::spawn(server_future)
 ```
 
-**Note:** For HTTP listeners, the flow is:
+**Note:** Both HTTP and HTTPS listeners share the same flow:
 `tokio::net::TcpListener::bind()` -> `into_std()` -> `configure_tcp_socket()`
--> `axum_server::Server::from_tcp()`. The conversion to `std::net::TcpListener`
-is necessary because `socket2::SockRef` requires a standard library socket.
+-> `axum_server::Server::from_tcp()` (the HTTPS path then chains `.acceptor()`).
+The conversion to `std::net::TcpListener` is necessary because `socket2::SockRef`
+requires a standard library socket.
 
 ### 8.3 TCP Socket Configuration
 

--- a/src/server/http.rs
+++ b/src/server/http.rs
@@ -158,13 +158,41 @@ async fn setup_https_listener(
     .await
     {
         Some(rustls_config) => {
+            // Bind and tune the TCP socket ourselves (mirroring the HTTP path) so
+            // the HTTPS listener gets the same keep-alive / TCP_NODELAY settings,
+            // then attach the TLS-info acceptor via `from_tcp`. `Server::bind`
+            // would bind internally and skip `configure_tcp_socket`.
+            let std_listener = match tokio::net::TcpListener::bind(sock_addr).await {
+                Ok(listener) => match listener.into_std() {
+                    Ok(std_listener) => std_listener,
+                    Err(e) => {
+                        tracing::error!(
+                            "Failed to convert tokio listener to std for {}: {}. \
+                            Skipping this HTTPS listener.",
+                            sock_addr,
+                            e
+                        );
+                        return;
+                    }
+                },
+                Err(e) => {
+                    tracing::error!(
+                        "Failed to bind HTTPS listener for {}: {}. Skipping this listener.",
+                        sock_addr,
+                        e
+                    );
+                    return;
+                }
+            };
+            configure_tcp_socket(&std_listener, config);
+
             tracing::info!("Starting HTTPS server on https://{}", sock_addr);
             // Use a TLS-info-injecting acceptor (instead of `bind_rustls`) so the
             // negotiated TLS parameters reach the `/get` and `/anything` handlers
             // as a request extension. ALPN/HTTP-2 and graceful shutdown are
             // unaffected — the wrapper delegates the handshake to `RustlsAcceptor`.
             let acceptor = crate::server::tls::TlsInfoAcceptor::new(rustls_config);
-            let mut server = axum_server::Server::bind(sock_addr).acceptor(acceptor);
+            let mut server = axum_server::Server::from_tcp(std_listener).acceptor(acceptor);
             configure_http_builder(&mut server, config);
             let server_future = server
                 .handle(handle)


### PR DESCRIPTION
## Summary

Quick win **#3** (ROADMAP T5, audit finding): the HTTPS listener was missing TCP socket tuning.

`configure_tcp_socket` (keep-alive + `TCP_NODELAY`) ran only on the HTTP path. The HTTPS path used `axum_server::Server::bind(addr)`, which binds the socket internally — so the tuning never applied to HTTPS connections. Now the HTTPS path **binds the listener itself**, applies `configure_tcp_socket`, and attaches the TLS-info acceptor via `from_tcp()` — exactly mirroring the HTTP path. ALPN/HTTP-2 and graceful shutdown are unaffected (same acceptor, just `from_tcp` instead of `bind`).

## Changes

- `src/server/http.rs` — `setup_https_listener` binds → `into_std()` → `configure_tcp_socket()` → `Server::from_tcp().acceptor(...)`, with the same bind/convert error handling as the HTTP path.
- Docs — CHANGELOG `[Unreleased]` (Fixed), ROADMAP tick, INTERNALS request-flow diagram + note updated (both listeners now share the `bind → tune → from_tcp` flow; the old text said only HTTP tuned the socket).

## On testing

No new unit test: socket options (`SO_KEEPALIVE`/`TCP_NODELAY`) aren't observable from the reqwest integration harness, and the change reuses the already-proven HTTP-path helper. The existing HTTPS/TLS integration tests (`test_get_echoes_tls_info_over_https`, `test_anything_echoes_tls_info_over_https`) exercise the listener path and still pass.

## Verification

`cargo fmt` · `clippy --all-targets --all-features -- -D warnings` (0) · `cargo test --all-features` (181 unit + 58 integration + 1 doc) — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)