### PR TITLE
ci: Attach SHA256SUMS to GitHub releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,6 +51,14 @@ jobs:
       - name: Build .deb package
         run: cargo deb
 
+      - name: Generate SHA256SUMS
+        run: |
+          # Basenames (no paths) so `sha256sum -c SHA256SUMS` verifies the files
+          # as downloaded alongside the checksum file.
+          ( cd target/release && sha256sum rucho ) > SHA256SUMS
+          ( cd target/debian && sha256sum *.deb ) >> SHA256SUMS
+          cat SHA256SUMS
+
       - name: Extract version from tag
         id: version
         run: echo "VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
@@ -72,7 +80,8 @@ jobs:
             --title "$GITHUB_REF_NAME" \
             --notes-file /tmp/release-notes.md \
             target/release/rucho \
-            target/debian/*.deb
+            target/debian/*.deb \
+            SHA256SUMS
 
   docker:
     name: Docker Push

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - `DELETE /cookies` — RESTful symmetry with `GET /cookies/delete`: expires each cookie named in the query (`Max-Age=0`) and `302`-redirects to `/cookies`. Registered as the `DELETE` method on the existing `/cookies` path and shares a single `expire_cookies` helper with the GET form.
 - `/metrics` is now documented in the OpenAPI spec / Swagger UI — annotated with `#[utoipa::path]` and registered in `ApiDoc`, with a response description noting it's only mounted when `metrics_enabled`. Previously the endpoint was invisible in Swagger. It stays out of the `/endpoints` runtime list, which reflects always-mounted routes.
+- GitHub releases now attach a `SHA256SUMS` file — checksums for the release binary and `.deb` package (listed by basename) — so downloads can be integrity-verified with `sha256sum -c SHA256SUMS`. Takes effect on the next tagged release.
 
 ### Fixed
 - The HTTPS listener now receives the same TCP socket tuning (keep-alive, `TCP_NODELAY`) as the HTTP listener. `configure_tcp_socket` previously ran only on the HTTP path — the HTTPS path used `axum_server::Server::bind`, which binds internally and skipped it. The HTTPS path now binds + tunes the listener and attaches the TLS-info acceptor via `from_tcp`.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -121,8 +121,8 @@ Docker/release ergonomics at **single-maintainer scope** — explicitly *not* pr
 - [x] **[M]** Read-only-filesystem compatibility — PID path is now configurable (`pid_file` / `RUCHO_PID_FILE`, default `/var/run/rucho/rucho.pid`) **and** a write failure is non-fatal: the server warns and starts anyway instead of aborting under `--read-only` Docker (PR #150)
 - [ ] **[M]** Auto-generated self-signed TLS certs (`ssl_auto_cert = true`, ephemeral in-memory via `rcgen`) — zero-setup HTTPS for dev/test; a test-ergonomics win, not gateway-redundant
 - [ ] **[L]** Alpine image variant (smaller image)
-- [ ] **[L]** Parallelize CI `deb` + `docker` jobs (both depend only on `build`)
-- [ ] **[L]** Attach `SHA256SUMS` to GitHub releases — lightweight integrity, no recurring cost
+- [x] **[L]** Parallelize CI `deb` + `docker` jobs — already satisfied: both are `needs: build` in `ci.yml`, so they run concurrently once `build` passes (verified during the v1.5.0 quick-wins pass)
+- [x] **[L]** Attach `SHA256SUMS` to GitHub releases — `release.yml` writes a `SHA256SUMS` (release binary + `.deb`, listed by basename) and attaches it; verify with `sha256sum -c SHA256SUMS` (PR #177)
 - [x] **[L]** Apply TCP socket tuning to the HTTPS listener — the HTTPS path now binds + `configure_tcp_socket`s the listener (keep-alive, `TCP_NODELAY`) before attaching the TLS-info acceptor via `from_tcp`, matching the HTTP path (it had used `Server::bind`, which binds internally and skipped the tuning) (PR #176)
 - [x] **[L]** Annotated `/metrics` with `#[utoipa::path]` + registered it in `ApiDoc`, so it's now discoverable in Swagger / `openapi.json` (the response description notes it's only mounted when `metrics_enabled`). Deliberately left out of `/endpoints`, which lists always-mounted routes (PR #175)
 


### PR DESCRIPTION
## Summary

Quick wins **#4 + #5** (ROADMAP T5).

**#5 — `SHA256SUMS` on releases:** `release.yml` now generates a `SHA256SUMS` file (checksums for the release binary and the `.deb`, listed by **basename**) and attaches it to the GitHub release. Downloads can be integrity-verified with `sha256sum -c SHA256SUMS`. Lightweight, no recurring cost; takes effect on the next tag push.

**#4 — parallelize CI `deb` + `docker`:** already satisfied — both jobs are `needs: build` in `ci.yml`, so they run concurrently once `build` passes. No change needed; ticked honestly.

## Changes

- `.github/workflows/release.yml` — a `Generate SHA256SUMS` step (after the binary + `.deb` builds) and `SHA256SUMS` added to the `gh release create` asset list.
- Docs — CHANGELOG `[Unreleased]` (Added), ROADMAP (both items ticked).

## Verification

No automated test (the workflow only runs on a tag push). Validated locally: the basename-based generation produces a valid `SHA256SUMS`, and the `sha256sum -c SHA256SUMS` roundtrip verifies both files (`rucho: OK`, `*.deb: OK`). Indentation/structure mirrors the existing steps.

> Note: this is a release-workflow change, so it won't be exercised until the *next* `v*` tag — worth a glance at the first release after merge to confirm the `SHA256SUMS` asset appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)